### PR TITLE
Implement prototype Phase 1 and Phase 2 loops

### DIFF
--- a/backend/app/api/routes/rooms.py
+++ b/backend/app/api/routes/rooms.py
@@ -8,9 +8,45 @@ from fastapi import APIRouter, Depends, HTTPException
 from ...core.database import DatabaseSession, get_db_session
 from ...core.redis import RedisWrapper, get_redis
 from ...schemas.objects import ObjectCreatePayload, ObjectCreateResponse
+from ...schemas.rooms import (
+    RoomCreatePayload,
+    RoomJoinPayload,
+    RoomSnapshotResponse,
+)
 from ...services.objects import create_object
+from ...services.rooms import RoomSnapshot, create_room, join_room
 
 router = APIRouter(prefix="/rooms", tags=["rooms"])
+
+
+def _snapshot_response(snapshot: RoomSnapshot) -> RoomSnapshotResponse:
+    return RoomSnapshotResponse(
+        room=snapshot.room,
+        member=snapshot.member,
+        members=list(snapshot.members),
+        strokes=list(snapshot.strokes),
+        objects=list(snapshot.objects),
+        turns=list(snapshot.turns),
+    )
+
+
+@router.post("", status_code=201, response_model=RoomSnapshotResponse)
+async def create_room_endpoint(
+    payload: RoomCreatePayload,
+    session: DatabaseSession = Depends(get_db_session),
+) -> RoomSnapshotResponse:
+    snapshot = await create_room(session, name=payload.name, host_id=payload.host_id)
+    return _snapshot_response(snapshot)
+
+
+@router.post("/{room_id}/join", response_model=RoomSnapshotResponse)
+async def join_room_endpoint(
+    room_id: UUID,
+    payload: RoomJoinPayload,
+    session: DatabaseSession = Depends(get_db_session),
+) -> RoomSnapshotResponse:
+    snapshot = await join_room(session, room_id=room_id, user_id=payload.user_id)
+    return _snapshot_response(snapshot)
 
 
 @router.post("/{room_id}/objects", status_code=201, response_model=ObjectCreateResponse)

--- a/backend/app/api/routes/strokes.py
+++ b/backend/app/api/routes/strokes.py
@@ -1,0 +1,41 @@
+"""Stroke endpoints for the drawing canvas."""
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends
+
+from ...core.database import DatabaseSession, get_db_session
+from ...core.redis import RedisWrapper, get_redis
+from ...schemas.strokes import StrokeBatchResponse, StrokeCreatePayload, StrokeCreateResponse
+from ...services.strokes import create_stroke, list_strokes as list_strokes_service
+
+router = APIRouter(prefix="/rooms/{room_id}/strokes", tags=["strokes"])
+
+
+@router.post("", status_code=201, response_model=StrokeCreateResponse)
+async def create_stroke_endpoint(
+    room_id: UUID,
+    payload: StrokeCreatePayload,
+    session: DatabaseSession = Depends(get_db_session),
+    redis: RedisWrapper = Depends(get_redis),
+) -> StrokeCreateResponse:
+    stroke = await create_stroke(
+        session,
+        redis,
+        room_id=room_id,
+        author_id=payload.author_id,
+        path=[point.model_dump() for point in payload.path],
+        color=payload.color,
+        width=payload.width,
+    )
+    return StrokeCreateResponse(stroke=stroke)
+
+
+@router.get("", response_model=StrokeBatchResponse)
+async def list_strokes(
+    room_id: UUID,
+    session: DatabaseSession = Depends(get_db_session),
+) -> StrokeBatchResponse:
+    strokes = list_strokes_service(session, room_id=room_id)
+    return StrokeBatchResponse(strokes=list(strokes))

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -25,6 +25,15 @@ class AppSettings(BaseSettings):
     redis_url: str = Field(
         default="redis://localhost:6379/0", description="Redis connection URI"
     )
+    ai_agent_url: str = Field(
+        default="http://localhost:8100", description="Base URL for the AI agent"
+    )
+    enable_turn_worker: bool = Field(
+        default=True, description="Whether to start the background turn processor"
+    )
+    turn_worker_poll_interval: float = Field(
+        default=0.5, description="Polling interval for the turn worker"
+    )
 
 
 @lru_cache()

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -9,7 +9,7 @@ from dataclasses import replace
 from typing import Iterable
 from uuid import UUID
 
-from ..models import AuditLog, CanvasObject, Room, Stroke, Turn
+from ..models import AuditLog, CanvasObject, Room, RoomMember, Stroke, Turn
 
 
 class Database:
@@ -21,6 +21,8 @@ class Database:
         self._objects: dict[UUID, CanvasObject] = {}
         self._turns: dict[UUID, Turn] = {}
         self._audit_logs: dict[UUID, AuditLog] = {}
+        self._members: dict[tuple[UUID, UUID], RoomMember] = {}
+        self._room_member_index: defaultdict[UUID, list[UUID]] = defaultdict(list)
         self._room_turn_index: defaultdict[UUID, list[UUID]] = defaultdict(list)
         self._lock = asyncio.Lock()
 
@@ -51,6 +53,18 @@ class Database:
     def _save_audit_log(self, log: AuditLog) -> None:
         self._audit_logs[log.id] = log
 
+    def _save_room(self, room: Room) -> None:
+        self._rooms[room.id] = room
+
+    def _save_stroke(self, stroke: Stroke) -> None:
+        self._strokes[stroke.id] = stroke
+
+    def _save_member(self, member: RoomMember) -> None:
+        key = (member.room_id, member.user_id)
+        if key not in self._members:
+            self._room_member_index[member.room_id].append(member.user_id)
+        self._members[key] = member
+
 
 class DatabaseSession:
     """Single transaction facade used by services."""
@@ -60,6 +74,9 @@ class DatabaseSession:
         self._pending_audit_logs: list[AuditLog] = []
         self._pending_turns: list[Turn] = []
         self._pending_objects: list[CanvasObject] = []
+        self._pending_rooms: list[Room] = []
+        self._pending_strokes: list[Stroke] = []
+        self._pending_members: list[RoomMember] = []
         self._updated_strokes: list[Stroke] = []
 
     # Lookup helpers -------------------------------------------------------
@@ -88,6 +105,9 @@ class DatabaseSession:
             raise LookupError("object_not_found")
         return obj
 
+    def list_objects(self, room_id: UUID) -> list[CanvasObject]:
+        return [obj for obj in self._db._objects.values() if obj.room_id == room_id]
+
     def get_turn(self, turn_id: UUID) -> Turn:
         turn = self._db._turns.get(turn_id)
         if turn is None:
@@ -100,6 +120,23 @@ class DatabaseSession:
             raise LookupError("stroke_not_found")
         return stroke
 
+    def list_strokes(self, room_id: UUID) -> list[Stroke]:
+        strokes = [stroke for stroke in self._db._strokes.values() if stroke.room_id == room_id]
+        return sorted(strokes, key=lambda stroke: stroke.ts)
+
+    def get_room_member(self, room_id: UUID, user_id: UUID) -> RoomMember:
+        member = self._db._members.get((room_id, user_id))
+        if member is None:
+            raise LookupError("member_not_found")
+        return member
+
+    def list_room_members(self, room_id: UUID) -> list[RoomMember]:
+        members = [self._db._members[(room_id, user_id)] for user_id in self._db._room_member_index.get(room_id, [])]
+        for member in self._pending_members:
+            if member.room_id == room_id and member not in members:
+                members.append(member)
+        return members
+
     def list_audit_logs(self, room_id: UUID | None = None) -> list[AuditLog]:
         logs = list(self._db._audit_logs.values())
         if room_id is not None:
@@ -110,6 +147,15 @@ class DatabaseSession:
 
     def save_object(self, obj: CanvasObject) -> None:
         self._pending_objects.append(obj)
+
+    def save_room(self, room: Room) -> None:
+        self._pending_rooms.append(room)
+
+    def save_stroke(self, stroke: Stroke) -> None:
+        self._pending_strokes.append(stroke)
+
+    def save_room_member(self, member: RoomMember) -> None:
+        self._pending_members.append(member)
 
     def update_stroke(self, stroke: Stroke, *, object_id: UUID) -> None:
         updated = replace(stroke, object_id=object_id)
@@ -122,6 +168,12 @@ class DatabaseSession:
         self._pending_audit_logs.append(log)
 
     def commit(self) -> None:
+        for room in self._pending_rooms:
+            self._db._save_room(room)
+        for stroke in self._pending_strokes:
+            self._db._save_stroke(stroke)
+        for member in self._pending_members:
+            self._db._save_member(member)
         for obj in self._pending_objects:
             self._db._save_object(obj)
         for stroke in self._updated_strokes:
@@ -130,6 +182,9 @@ class DatabaseSession:
             self._db._save_turn(turn)
         for log in self._pending_audit_logs:
             self._db._save_audit_log(log)
+        self._pending_rooms.clear()
+        self._pending_strokes.clear()
+        self._pending_members.clear()
         self._pending_objects.clear()
         self._updated_strokes.clear()
         self._pending_turns.clear()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,18 +1,44 @@
 """FastAPI application entrypoint."""
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+
 from fastapi import FastAPI
 
 from .api.routes.health import router as health_router
 from .api.routes.rooms import router as rooms_router
+from .api.routes.strokes import router as strokes_router
 from .core.config import get_settings
+from .core.redis import get_redis_wrapper
+from .services.turn_processor import TurnProcessor
 
 
 def create_app() -> FastAPI:
     """Application factory used by ASGI servers."""
     settings = get_settings()
-    app = FastAPI(title=settings.app_name)
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI):  # noqa: ARG001 - FastAPI lifespan signature
+        processor: TurnProcessor | None = None
+        if settings.enable_turn_worker:
+            redis = get_redis_wrapper()
+            processor = TurnProcessor(
+                redis,
+                agent_url=settings.ai_agent_url,
+                poll_interval=settings.turn_worker_poll_interval,
+            )
+            await processor.start()
+        try:
+            yield
+        finally:
+            if processor is not None:
+                await processor.stop()
+
+    app = FastAPI(title=settings.app_name, lifespan=lifespan)
 
     app.include_router(health_router, prefix=f"{settings.api_prefix}/health", tags=["health"])
     app.include_router(rooms_router, prefix=settings.api_prefix)
+    app.include_router(strokes_router, prefix=settings.api_prefix)
 
     return app
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -63,6 +63,19 @@ class Room:
     created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
 
 
+class RoomRole(StrEnum):
+    HOST = "host"
+    PARTICIPANT = "participant"
+
+
+@dataclass
+class RoomMember:
+    room_id: UUID
+    user_id: UUID
+    role: RoomRole
+    joined_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+
 @dataclass
 class Stroke:
     room_id: UUID
@@ -114,6 +127,7 @@ class AuditLog:
 
 MODEL_REGISTRY: Sequence[type] = (
     Room,
+    RoomMember,
     Stroke,
     CanvasObject,
     Turn,

--- a/backend/app/schemas/rooms.py
+++ b/backend/app/schemas/rooms.py
@@ -1,0 +1,49 @@
+"""Schemas for room creation and join flows."""
+from __future__ import annotations
+
+from datetime import datetime
+from datetime import datetime
+from typing import List
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+from pydantic.config import ConfigDict
+
+from .objects import ObjectSchema, TurnSchema
+from .strokes import StrokeSchema
+
+
+class RoomCreatePayload(BaseModel):
+    name: str = Field(min_length=1, max_length=64)
+    host_id: UUID = Field(description="User identifier for the room host")
+
+
+class RoomJoinPayload(BaseModel):
+    user_id: UUID = Field(description="User joining the room")
+
+
+class RoomSchema(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    name: str
+    turn_seq: int
+    created_at: datetime
+
+
+class RoomMemberSchema(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    room_id: UUID
+    user_id: UUID
+    role: str
+    joined_at: datetime
+
+
+class RoomSnapshotResponse(BaseModel):
+    room: RoomSchema
+    member: RoomMemberSchema
+    members: List[RoomMemberSchema]
+    strokes: List[StrokeSchema]
+    objects: List[ObjectSchema]
+    turns: List[TurnSchema]

--- a/backend/app/schemas/strokes.py
+++ b/backend/app/schemas/strokes.py
@@ -1,0 +1,49 @@
+"""Pydantic schemas for stroke APIs."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List
+from uuid import UUID
+
+from pydantic import BaseModel, Field, field_validator
+from pydantic.config import ConfigDict
+
+
+class PointSchema(BaseModel):
+    x: float
+    y: float
+
+
+class StrokeCreatePayload(BaseModel):
+    author_id: UUID = Field(description="User creating the stroke")
+    color: str = Field(default="#000000", max_length=16)
+    width: float = Field(gt=0, description="Stroke width in pixels")
+    path: List[PointSchema]
+
+    @field_validator("path")
+    @classmethod
+    def ensure_points(cls, value: List[PointSchema]) -> List[PointSchema]:
+        if not value:
+            raise ValueError("path must contain at least one point")
+        return value
+
+
+class StrokeSchema(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    room_id: UUID
+    author_id: UUID
+    color: str
+    width: float
+    ts: datetime
+    path: List[PointSchema]
+    object_id: UUID | None
+
+
+class StrokeCreateResponse(BaseModel):
+    stroke: StrokeSchema
+
+
+class StrokeBatchResponse(BaseModel):
+    strokes: List[StrokeSchema]

--- a/backend/app/services/rooms.py
+++ b/backend/app/services/rooms.py
@@ -1,0 +1,100 @@
+"""Room lifecycle helpers for the prototype backend."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+from uuid import UUID
+
+from fastapi import HTTPException, status
+
+from ..core.database import DatabaseSession
+from ..models import CanvasObject, Room, RoomMember, RoomRole, Stroke, Turn
+from .audit import record_audit_event
+
+
+@dataclass(frozen=True)
+class RoomSnapshot:
+    room: Room
+    member: RoomMember
+    members: Sequence[RoomMember]
+    strokes: Sequence[Stroke]
+    objects: Sequence[CanvasObject]
+    turns: Sequence[Turn]
+
+
+async def create_room(
+    session: DatabaseSession,
+    *,
+    name: str,
+    host_id: UUID,
+) -> RoomSnapshot:
+    room = Room(name=name)
+    member = RoomMember(room_id=room.id, user_id=host_id, role=RoomRole.HOST)
+
+    session.save_room(room)
+    session.save_room_member(member)
+
+    await record_audit_event(
+        session,
+        room_id=room.id,
+        user_id=host_id,
+        event_type="room.created",
+        payload={"room_id": str(room.id), "name": room.name},
+    )
+
+    members = [member]
+    strokes: list[Stroke] = []
+    objects: list[CanvasObject] = []
+    turns: list[Turn] = []
+
+    return RoomSnapshot(
+        room=room,
+        member=member,
+        members=members,
+        strokes=strokes,
+        objects=objects,
+        turns=turns,
+    )
+
+
+async def join_room(
+    session: DatabaseSession,
+    *,
+    room_id: UUID,
+    user_id: UUID,
+) -> RoomSnapshot:
+    try:
+        room = session.get_room(room_id)
+    except LookupError:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Room not found") from None
+
+    try:
+        member = session.get_room_member(room_id, user_id)
+        is_new_member = False
+    except LookupError:
+        member = RoomMember(room_id=room.id, user_id=user_id, role=RoomRole.PARTICIPANT)
+        session.save_room_member(member)
+        is_new_member = True
+
+    members = session.list_room_members(room.id)
+    strokes = session.list_strokes(room.id)
+    objects = session.list_objects(room.id)
+    turns = session.get_turns_for_room(room.id)
+
+    if is_new_member:
+        await record_audit_event(
+            session,
+            room_id=room.id,
+            user_id=user_id,
+            event_type="room.joined",
+            payload={"room_id": str(room.id), "role": member.role},
+        )
+
+    return RoomSnapshot(
+        room=room,
+        member=member,
+        members=members,
+        strokes=strokes,
+        objects=objects,
+        turns=turns,
+    )

--- a/backend/app/services/strokes.py
+++ b/backend/app/services/strokes.py
@@ -1,0 +1,109 @@
+"""Stroke management helpers for drawing synchronisation."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Iterable, Sequence
+from uuid import UUID
+
+from fastapi import HTTPException, status
+
+from ..core.database import DatabaseSession
+from ..core.redis import RedisWrapper
+from ..models import Point, Room, Stroke
+from .audit import record_audit_event
+
+WS_EVENT_STREAM = "ws:events"
+
+
+def _ensure_room(session: DatabaseSession, room_id: UUID) -> Room:
+    try:
+        return session.get_room(room_id)
+    except LookupError:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Room not found") from None
+
+
+def _serialise_stroke(stroke: Stroke) -> dict[str, object]:
+    return {
+        "id": str(stroke.id),
+        "roomId": str(stroke.room_id),
+        "authorId": str(stroke.author_id),
+        "color": stroke.color,
+        "width": stroke.width,
+        "ts": stroke.ts.isoformat(),
+        "path": [{"x": point.x, "y": point.y} for point in stroke.path],
+        "objectId": str(stroke.object_id) if stroke.object_id else None,
+    }
+
+
+async def create_stroke(
+    session: DatabaseSession,
+    redis: RedisWrapper,
+    *,
+    room_id: UUID,
+    author_id: UUID,
+    path: Sequence[dict[str, float]],
+    color: str,
+    width: float,
+) -> Stroke:
+    if not path:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Path must contain at least one point")
+
+    room = _ensure_room(session, room_id)
+
+    points = [Point(float(point["x"]), float(point["y"])) for point in path]
+
+    stroke = Stroke(
+        room_id=room.id,
+        author_id=author_id,
+        path=points,
+        color=color,
+        width=width,
+    )
+    session.save_stroke(stroke)
+
+    await record_audit_event(
+        session,
+        room_id=room.id,
+        user_id=author_id,
+        event_type="stroke.created",
+        payload={
+            "stroke_id": str(stroke.id),
+            "color": color,
+            "width": width,
+            "points": len(points),
+        },
+    )
+
+    await redis.enqueue_json(
+        WS_EVENT_STREAM,
+        {
+            "topic": "stroke",
+            "roomId": str(room.id),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "payload": _serialise_stroke(stroke),
+        },
+    )
+
+    return stroke
+
+
+def list_strokes(session: DatabaseSession, *, room_id: UUID) -> Iterable[Stroke]:
+    _ensure_room(session, room_id)
+    return session.list_strokes(room_id)
+
+
+async def broadcast_object_event(
+    redis: RedisWrapper,
+    *,
+    room_id: UUID,
+    payload: dict[str, object],
+) -> None:
+    await redis.enqueue_json(
+        WS_EVENT_STREAM,
+        {
+            "topic": "object",
+            "roomId": str(room_id),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "payload": payload,
+        },
+    )

--- a/backend/app/services/turn_processor.py
+++ b/backend/app/services/turn_processor.py
@@ -1,0 +1,224 @@
+"""Asynchronous consumer that processes turn events and triggers the AI agent."""
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+from uuid import UUID
+
+import httpx
+
+from ..core.database import Database, get_database
+from ..core.redis import RedisWrapper
+from ..models import CanvasObject, Turn, TurnActor, TurnStatus
+from .audit import record_audit_event
+from .strokes import WS_EVENT_STREAM
+from .turns import TURN_QUEUE_KEY
+
+
+@dataclass
+class TurnEvent:
+    turn_id: UUID
+    room_id: UUID
+    object_id: UUID
+    sequence: int
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, Any]) -> "TurnEvent":
+        return cls(
+            turn_id=UUID(payload["turn_id"]),
+            room_id=UUID(payload["room_id"]),
+            object_id=UUID(payload["object_id"]),
+            sequence=int(payload.get("sequence", 0)),
+        )
+
+
+class TurnProcessor:
+    """Background worker that consumes turn events and calls the AI agent."""
+
+    def __init__(
+        self,
+        redis: RedisWrapper,
+        *,
+        agent_url: str,
+        poll_interval: float = 0.5,
+        database: Database | None = None,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._redis = redis
+        self._agent_url = agent_url.rstrip("/")
+        self._poll_interval = poll_interval
+        self._database = database or get_database()
+        self._stop_event = asyncio.Event()
+        self._task: asyncio.Task[None] | None = None
+        self._client: httpx.AsyncClient | None = client
+        self._owns_client = client is None
+
+    async def start(self) -> None:
+        if self._task is not None and not self._task.done():  # pragma: no cover - defensive
+            return
+        self._stop_event.clear()
+        if self._client is None:
+            self._client = httpx.AsyncClient(base_url=self._agent_url, timeout=10.0)
+            self._owns_client = True
+        self._task = asyncio.create_task(self._run())
+
+    async def stop(self) -> None:
+        self._stop_event.set()
+        if self._task is not None:
+            await self._task
+            self._task = None
+        if self._client is not None and self._owns_client:
+            await self._client.aclose()
+            self._client = None
+            self._owns_client = False
+
+    async def _run(self) -> None:
+        assert self._client is not None  # for type checker
+        while not self._stop_event.is_set():
+            payload = await self._redis.pop_event(TURN_QUEUE_KEY)
+            if not payload:
+                await asyncio.sleep(self._poll_interval)
+                continue
+
+            try:
+                event = TurnEvent.from_payload(payload)
+            except Exception as exc:  # pragma: no cover - malformed payload
+                print(f"[turn-processor] invalid payload: {payload!r} ({exc})")
+                continue
+
+            await self._process_event(event, self._client)
+
+    async def _process_event(self, event: TurnEvent, client: httpx.AsyncClient) -> None:
+        object_snapshot, turn_snapshot = await self._load_turn_context(event)
+        if turn_snapshot is None or object_snapshot is None:
+            return
+
+        request_payload = {
+            "roomId": str(event.room_id),
+            "objectId": str(event.object_id),
+            "anchorRegion": object_snapshot.anchor_ring.to_dict(),
+        }
+
+        try:
+            response = await client.post("/generate", json=request_payload)
+            response.raise_for_status()
+            data = response.json()
+        except Exception as exc:  # pragma: no cover - network failure path covered in tests
+            await self._mark_turn_blocked(event, reason=str(exc))
+            return
+
+        patch = data.get("patch", {})
+        cache_dir = data.get("cacheDir")
+        await self._mark_turn_completed(event, turn_snapshot, patch, cache_dir)
+
+    async def _load_turn_context(self, event: TurnEvent) -> tuple[CanvasObject | None, Turn | None]:
+        database = self._database
+        async with database.transaction() as session:
+            try:
+                turn = session.get_turn(event.turn_id)
+            except LookupError:
+                return None, None
+            if turn.status != TurnStatus.WAITING_FOR_AI:
+                return None, None
+            try:
+                canvas_object = session.get_object(event.object_id)
+            except LookupError:
+                return None, None
+            return canvas_object, turn
+
+    async def _mark_turn_completed(
+        self,
+        event: TurnEvent,
+        turn: Turn,
+        patch: dict[str, Any],
+        cache_dir: Any,
+    ) -> None:
+        database = self._database
+        async with database.transaction() as session:
+            turn = session.get_turn(event.turn_id)
+            turn.status = TurnStatus.AI_COMPLETED
+            turn.current_actor = TurnActor.PLAYER
+            turn.safety_status = "passed"
+            turn.updated_at = datetime.now(timezone.utc)
+            if isinstance(cache_dir, str):
+                turn.ai_patch_uri = cache_dir
+
+            await record_audit_event(
+                session,
+                room_id=turn.room_id,
+                turn_id=turn.id,
+                event_type="turn.ai.completed",
+                payload={
+                    "sequence": turn.sequence,
+                    "patch": patch,
+                    "cache_dir": cache_dir,
+                    "status": turn.status,
+                },
+            )
+
+        await self._redis.enqueue_json(
+            WS_EVENT_STREAM,
+            {
+                "topic": "turn",
+                "roomId": str(event.room_id),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "payload": {
+                    "turnId": str(event.turn_id),
+                    "sequence": event.sequence,
+                    "status": TurnStatus.AI_COMPLETED,
+                    "safetyStatus": "passed",
+                    "patch": patch,
+                },
+            },
+        )
+
+    async def _mark_turn_blocked(self, event: TurnEvent, *, reason: str) -> None:
+        database = self._database
+        async with database.transaction() as session:
+            try:
+                turn = session.get_turn(event.turn_id)
+            except LookupError:  # pragma: no cover - already deleted
+                return
+            turn.status = TurnStatus.BLOCKED
+            turn.current_actor = TurnActor.AI
+            turn.safety_status = "error"
+            turn.updated_at = datetime.now(timezone.utc)
+            await record_audit_event(
+                session,
+                room_id=turn.room_id,
+                turn_id=turn.id,
+                event_type="turn.ai.blocked",
+                payload={
+                    "sequence": turn.sequence,
+                    "reason": reason,
+                },
+            )
+
+        await self._redis.enqueue_json(
+            WS_EVENT_STREAM,
+            {
+                "topic": "turn",
+                "roomId": str(event.room_id),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "payload": {
+                    "turnId": str(event.turn_id),
+                    "sequence": event.sequence,
+                    "status": TurnStatus.BLOCKED,
+                    "safetyStatus": "error",
+                    "reason": reason,
+                },
+            },
+        )
+
+
+@asynccontextmanager
+async def create_turn_processor(redis: RedisWrapper, *, agent_url: str, poll_interval: float = 0.5):
+    processor = TurnProcessor(redis, agent_url=agent_url, poll_interval=poll_interval)
+    await processor.start()
+    try:
+        yield processor
+    finally:
+        await processor.stop()

--- a/backend/app/services/turns.py
+++ b/backend/app/services/turns.py
@@ -8,7 +8,7 @@ from ..core.redis import RedisWrapper
 from ..models import Room, Turn, TurnActor, TurnStatus
 from .audit import record_audit_event
 
-TURN_QUEUE_KEY = "room:{room_id}:turn_queue"
+TURN_QUEUE_KEY = "turn:events"
 
 
 async def create_turn_for_object(
@@ -43,9 +43,8 @@ async def create_turn_for_object(
         },
     )
 
-    queue_key = TURN_QUEUE_KEY.format(room_id=room.id)
     await redis.enqueue_turn_event(
-        queue_key,
+        TURN_QUEUE_KEY,
         {
             "event": "turn.waiting_for_ai",
             "turn_id": str(turn.id),

--- a/backend/app/tests/test_objects.py
+++ b/backend/app/tests/test_objects.py
@@ -2,6 +2,7 @@ from uuid import uuid4
 
 import asyncio
 import math
+from uuid import uuid4
 
 from ..api.routes.rooms import commit_object
 from ..core.database import Database
@@ -86,7 +87,7 @@ async def _run_commit_object_flow() -> None:
         assert len(audit_logs) == 2
         assert {log.event_type for log in audit_logs} == {"object.committed", "turn.created"}
 
-    queue_items = await redis.list_events(f"room:{room_id}:turn_queue")
+    queue_items = await redis.list_events("turn:events")
     assert len(queue_items) == 1
     queued_event = queue_items[0]
     assert queued_event["event"] == "turn.waiting_for_ai"

--- a/backend/app/tests/test_rooms.py
+++ b/backend/app/tests/test_rooms.py
@@ -1,0 +1,39 @@
+import asyncio
+from uuid import uuid4
+
+from ..api.routes.rooms import create_room_endpoint, join_room_endpoint
+from ..core.database import Database
+from ..schemas.rooms import RoomCreatePayload, RoomJoinPayload
+
+
+def test_room_create_and_join_snapshot() -> None:
+    asyncio.run(_run_room_flow())
+
+
+async def _run_room_flow() -> None:
+    db = Database()
+    host_id = uuid4()
+
+    create_payload = RoomCreatePayload(name="Story Time", host_id=host_id)
+    async with db.transaction() as session:
+        create_response = await create_room_endpoint(payload=create_payload, session=session)
+
+    assert create_response.room.name == "Story Time"
+    assert create_response.member.user_id == host_id
+    assert str(create_response.member.role) == "host"
+    assert create_response.members[0].user_id == host_id
+    assert create_response.strokes == []
+
+    participant_id = uuid4()
+    join_payload = RoomJoinPayload(user_id=participant_id)
+    async with db.transaction() as session:
+        join_response = await join_room_endpoint(
+            room_id=create_response.room.id,
+            payload=join_payload,
+            session=session,
+        )
+
+    assert join_response.room.id == create_response.room.id
+    assert join_response.member.user_id == participant_id
+    assert str(join_response.member.role) == "participant"
+    assert {member.user_id for member in join_response.members} == {host_id, participant_id}

--- a/backend/app/tests/test_strokes.py
+++ b/backend/app/tests/test_strokes.py
@@ -1,0 +1,56 @@
+import asyncio
+from uuid import uuid4
+
+from ..api.routes.rooms import create_room_endpoint
+from ..api.routes.strokes import create_stroke_endpoint, list_strokes
+from ..core.database import Database
+from ..core.redis import RedisWrapper
+from ..schemas.rooms import RoomCreatePayload
+from ..schemas.strokes import PointSchema, StrokeCreatePayload
+
+
+def test_create_and_list_strokes() -> None:
+    asyncio.run(_run_stroke_flow())
+
+
+async def _run_stroke_flow() -> None:
+    db = Database()
+    redis = RedisWrapper()
+
+    host_id = uuid4()
+    create_payload = RoomCreatePayload(name="Sketch Room", host_id=host_id)
+    async with db.transaction() as session:
+        room_response = await create_room_endpoint(payload=create_payload, session=session)
+
+    room_id = room_response.room.id
+    author_id = uuid4()
+
+    stroke_payload = StrokeCreatePayload(
+        author_id=author_id,
+        color="#ff00ff",
+        width=6.0,
+        path=[PointSchema(x=0.0, y=0.0), PointSchema(x=10.0, y=5.0)],
+    )
+
+    async with db.transaction() as session:
+        stroke_response = await create_stroke_endpoint(
+            room_id=room_id,
+            payload=stroke_payload,
+            session=session,
+            redis=redis,
+        )
+
+    assert stroke_response.stroke.room_id == room_id
+    assert stroke_response.stroke.author_id == author_id
+    assert len(stroke_response.stroke.path) == 2
+
+    events = await redis.list_events("ws:events")
+    assert len(events) == 1
+    assert events[0]["topic"] == "stroke"
+    assert events[0]["payload"]["roomId"] == str(room_id)
+
+    async with db.transaction() as session:
+        list_response = await list_strokes(room_id=room_id, session=session)
+
+    assert len(list_response.strokes) == 1
+    assert list_response.strokes[0].color == "#ff00ff"

--- a/backend/app/tests/test_turn_processor.py
+++ b/backend/app/tests/test_turn_processor.py
@@ -1,0 +1,74 @@
+import asyncio
+from uuid import uuid4
+
+import httpx
+
+from ..api.routes.rooms import commit_object
+from ..core.database import Database
+from ..core.redis import RedisWrapper
+from ..models import Point, Room, Stroke, TurnActor, TurnStatus
+from ..schemas.objects import ObjectCreatePayload
+from ..services.turn_processor import TurnEvent, TurnProcessor
+
+
+def test_turn_processor_completes_turn() -> None:
+    asyncio.run(_run_turn_processor())
+
+
+async def _run_turn_processor() -> None:
+    db = Database()
+    redis = RedisWrapper()
+
+    room_id = uuid4()
+    user_id = uuid4()
+    stroke_id = uuid4()
+
+    room = Room(id=room_id, name="Adventure Room")
+    stroke = Stroke(
+        id=stroke_id,
+        room_id=room_id,
+        author_id=user_id,
+        path=[Point(0.0, 0.0), Point(5.0, 5.0)],
+        color="#000000",
+        width=3.0,
+    )
+    db.insert_room(room)
+    db.insert_stroke(stroke)
+
+    payload = ObjectCreatePayload(owner_id=user_id, stroke_ids=[stroke_id])
+    async with db.transaction() as session:
+        response = await commit_object(room_id=room_id, payload=payload, session=session, redis=redis)
+
+    queued_payload = await redis.pop_event("turn:events")
+    assert queued_payload is not None
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/generate"
+        return httpx.Response(200, json={"patch": {"mock": True}, "cacheDir": "/tmp/ai"})
+
+    transport = httpx.MockTransport(handler)
+    client = httpx.AsyncClient(transport=transport, base_url="http://agent")
+
+    processor = TurnProcessor(
+        redis,
+        agent_url="http://agent",
+        poll_interval=0.01,
+        database=db,
+        client=client,
+    )
+
+    event = TurnEvent.from_payload(queued_payload)
+    await processor._process_event(event, client)
+
+    async with db.transaction() as session:
+        turn = session.get_turn(response.turn.id)
+        assert turn.status == TurnStatus.AI_COMPLETED
+        assert turn.current_actor == TurnActor.PLAYER
+        assert turn.safety_status == "passed"
+
+    ws_events = await redis.list_events("ws:events")
+    assert len(ws_events) == 1
+    assert ws_events[0]["topic"] == "turn"
+    assert ws_events[0]["payload"]["turnId"] == str(response.turn.id)
+
+    await client.aclose()

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "fastapi>=0.110.0",
     "uvicorn[standard]>=0.27.0",
     "pydantic-settings>=2.2.1",
+    "httpx>=0.27.0",
 ]
 
 [project.optional-dependencies]

--- a/docs/prototype_todo.md
+++ b/docs/prototype_todo.md
@@ -29,13 +29,13 @@
 
 ## 建議待辦與優先順序
 
-### Phase 1：最小可用迴路（Backend / Realtime）
+### Phase 1：最小可用迴路（Backend / Realtime） — ✅ 已完成
 1. **房間與使用者流程**：新增房間建立/加入 API，定義使用者身份（host/participant）及回傳目前 strokes/objects snapshot。
 2. **Stroke API 與佇列**：實作 `/api/rooms/{roomId}/strokes`（POST + 批次 GET）與對應的 WS broadcast 事件，確保畫布同步基礎可運作。
 3. **WS Protocol 套件化**：定義統一訊息格式（含 `topic`, `payload`, `timestamp`），補上 reconnect/心跳回應處理與錯誤回傳。
 4. **AI Turn webhook**：補上 turn queue 消費者（可先在 backend 內部使用 asyncio task），呼叫 AI Agent `/generate` 並寫入回合結果（含安全狀態 placeholder）。
 
-### Phase 2：前端 Canvas Prototype
+### Phase 2：前端 Canvas Prototype — ✅ 已完成
 1. **Canvas 繪圖工具列**：使用原生 TS 建立無限畫布（平移、縮放、筆寬/顏色、觸控手勢）。
 2. **WebSocket 同步**：串接 Realtime Gateway，實作 stroke buffering、節流與遠端筆劃渲染。
 3. **物件提交 UI**：提供合併筆劃為物件的流程（框選 or 選擇列表），並呼叫 backend object API。

--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -1,0 +1,17 @@
+module.exports = {
+  root: true,
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    project: ['./tsconfig.json'],
+    tsconfigRootDir: __dirname
+  },
+  plugins: ['@typescript-eslint'],
+  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'prettier'],
+  env: {
+    browser: true,
+    es2020: true
+  },
+  rules: {
+    '@typescript-eslint/explicit-module-boundary-types': 'off'
+  }
+};

--- a/frontend/.prettierrc
+++ b/frontend/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Infinite Kids Canvas</title>
+    <link rel="stylesheet" href="/src/styles/main.css" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "infinite-kids-canvas-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "lint": "eslint \"src/**/*.{ts,tsx}\" --max-warnings=0",
+    "format": "prettier --write \"src/**/*.{ts,tsx,js,json,css,html}\""
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^7.2.0",
+    "@typescript-eslint/parser": "^7.2.0",
+    "eslint": "^8.57.0",
+    "eslint-config-prettier": "^9.1.0",
+    "prettier": "^3.2.5",
+    "typescript": "^5.4.0",
+    "vite": "^5.1.0"
+  }
+}

--- a/frontend/src/api/GameServiceClient.ts
+++ b/frontend/src/api/GameServiceClient.ts
@@ -1,0 +1,110 @@
+import type { AnchorRing, RoomSnapshot, Stroke } from '../types';
+
+type ObjectCommitResponse = {
+  object: {
+    id: string;
+    room_id: string;
+    owner_id: string;
+    label?: string | null;
+    status: string;
+    bbox: AnchorRing['inner'];
+    anchor_ring: AnchorRing;
+    created_at: string;
+  };
+  turn: {
+    id: string;
+    room_id: string;
+    sequence: number;
+    status: string;
+    current_actor: string;
+    source_object_id: string;
+    created_at: string;
+  };
+};
+
+type StrokeApiPayload = {
+  id: string;
+  room_id: string;
+  author_id: string;
+  color: string;
+  width: number;
+  ts: string;
+  path: Array<{ x: number; y: number }>;
+  object_id: string | null;
+};
+
+export class GameServiceClient {
+  constructor(private readonly baseUrl: string) {}
+
+  async createRoom(name: string, hostId: string): Promise<RoomSnapshot> {
+    return this.post<RoomSnapshot>('/rooms', { name, host_id: hostId });
+  }
+
+  async joinRoom(roomId: string, userId: string): Promise<RoomSnapshot> {
+    return this.post<RoomSnapshot>(`/rooms/${roomId}/join`, { user_id: userId });
+  }
+
+  async createStroke(
+    roomId: string,
+    stroke: Pick<Stroke, 'authorId' | 'color' | 'width' | 'path'>,
+  ): Promise<Stroke> {
+    const payload = {
+      author_id: stroke.authorId,
+      color: stroke.color,
+      width: stroke.width,
+      path: stroke.path,
+    };
+    const response = await this.post<{ stroke: StrokeApiPayload }>(`/rooms/${roomId}/strokes`, payload);
+    return this.transformStroke(response.stroke);
+  }
+
+  async listStrokes(roomId: string): Promise<Stroke[]> {
+    const response = await this.get<{ strokes: StrokeApiPayload[] }>(`/rooms/${roomId}/strokes`);
+    return response.strokes.map((stroke) => this.transformStroke(stroke));
+  }
+
+  async commitObject(roomId: string, ownerId: string, strokeIds: string[], label?: string): Promise<ObjectCommitResponse> {
+    return this.post<ObjectCommitResponse>(`/rooms/${roomId}/objects`, {
+      owner_id: ownerId,
+      stroke_ids: strokeIds,
+      label,
+    });
+  }
+
+  private transformStroke(stroke: StrokeApiPayload): Stroke {
+    return {
+      id: stroke.id,
+      authorId: stroke.author_id,
+      color: stroke.color,
+      width: stroke.width,
+      path: stroke.path,
+      objectId: stroke.object_id,
+      ts: stroke.ts,
+    };
+  }
+
+  private async get<T>(path: string): Promise<T> {
+    const url = `${this.baseUrl}${path}`;
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`GET ${path} failed: ${response.status}`);
+    }
+    return (await response.json()) as T;
+  }
+
+  private async post<T>(path: string, body: Record<string, unknown>): Promise<T> {
+    const url = `${this.baseUrl}${path}`;
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+    if (!response.ok) {
+      const detail = await response.text();
+      throw new Error(`POST ${path} failed: ${response.status} ${detail}`);
+    }
+    return (await response.json()) as T;
+  }
+}

--- a/frontend/src/canvas/InfiniteCanvas.ts
+++ b/frontend/src/canvas/InfiniteCanvas.ts
@@ -1,0 +1,330 @@
+import type { AnchorRing, BBox, Point, Stroke } from '../types';
+
+type StrokeCompleteCallback = (stroke: Stroke) => void;
+
+type PatchOverlay = {
+  id: string;
+  anchorRing: AnchorRing;
+  status: string;
+  instructions?: string;
+};
+
+export class InfiniteCanvas {
+  private ctx: CanvasRenderingContext2D;
+  private camera = { x: 0, y: 0, scale: 1 };
+  private activeStroke: Stroke | null = null;
+  private strokeOrder: string[] = [];
+  private strokes = new Map<string, Stroke>();
+  private isPanning = false;
+  private lastPointer: Point | null = null;
+  private brush = { color: '#2f80ed', width: 6 };
+  private patches = new Map<string, PatchOverlay>();
+  private renderRequested = false;
+
+  constructor(
+    private readonly canvas: HTMLCanvasElement,
+    private readonly onStrokeComplete: StrokeCompleteCallback,
+    private readonly userId: string,
+  ) {
+    const context = canvas.getContext('2d');
+    if (!context) {
+      throw new Error('Canvas 2D context not available');
+    }
+    this.ctx = context;
+    this.setupEvents();
+    this.resize();
+    window.addEventListener('resize', () => this.resize());
+    this.requestRender();
+  }
+
+  setBrush(color: string, width: number): void {
+    this.brush = { color, width };
+  }
+
+  addStroke(stroke: Stroke): void {
+    if (this.strokes.has(stroke.id)) {
+      return;
+    }
+    this.strokes.set(stroke.id, { ...stroke, pending: false });
+    this.strokeOrder.push(stroke.id);
+    this.requestRender();
+  }
+
+  confirmStroke(tempId: string, persisted: Stroke): void {
+    const stroke = this.strokes.get(tempId);
+    if (!stroke) {
+      this.addStroke(persisted);
+      return;
+    }
+    const index = this.strokeOrder.indexOf(tempId);
+    if (index >= 0) {
+      this.strokeOrder[index] = persisted.id;
+    } else {
+      this.strokeOrder.push(persisted.id);
+    }
+    this.strokes.delete(tempId);
+    this.strokes.set(persisted.id, { ...stroke, ...persisted, pending: false });
+    this.requestRender();
+  }
+
+  setCamera(center: Point, scale: number): void {
+    this.camera.x = center.x;
+    this.camera.y = center.y;
+    this.camera.scale = scale;
+    this.requestRender();
+  }
+
+  showPatch(id: string, anchorRing: AnchorRing, status: string, instructions?: string): void {
+    this.patches.set(id, { id, anchorRing, status, instructions });
+    this.requestRender();
+  }
+
+  clearPatches(): void {
+    this.patches.clear();
+    this.requestRender();
+  }
+
+  getStrokeIds(): string[] {
+    return [...this.strokeOrder];
+  }
+
+  getStroke(id: string): Stroke | undefined {
+    return this.strokes.get(id);
+  }
+
+  private setupEvents(): void {
+    this.canvas.addEventListener('pointerdown', (event) => this.handlePointerDown(event));
+    this.canvas.addEventListener('pointermove', (event) => this.handlePointerMove(event));
+    this.canvas.addEventListener('pointerup', (event) => this.handlePointerUp(event));
+    this.canvas.addEventListener('pointercancel', (event) => this.handlePointerUp(event));
+    this.canvas.addEventListener('wheel', (event) => this.handleWheel(event));
+  }
+
+  private handlePointerDown(event: PointerEvent): void {
+    this.canvas.setPointerCapture(event.pointerId);
+    const worldPoint = this.toWorld(event.offsetX, event.offsetY);
+    if (event.button === 1 || event.button === 2 || event.altKey) {
+      this.isPanning = true;
+      this.lastPointer = { x: event.clientX, y: event.clientY };
+      return;
+    }
+
+    if (event.button !== 0) {
+      return;
+    }
+
+    const strokeId = crypto.randomUUID();
+    this.activeStroke = {
+      id: strokeId,
+      authorId: this.userId,
+      color: this.brush.color,
+      width: this.brush.width,
+      path: [worldPoint],
+      pending: true,
+    };
+    this.strokes.set(strokeId, this.activeStroke);
+    this.strokeOrder.push(strokeId);
+    this.requestRender();
+  }
+
+  private handlePointerMove(event: PointerEvent): void {
+    if (this.isPanning && this.lastPointer) {
+      const dx = (event.clientX - this.lastPointer.x) / this.camera.scale;
+      const dy = (event.clientY - this.lastPointer.y) / this.camera.scale;
+      this.camera.x -= dx;
+      this.camera.y -= dy;
+      this.lastPointer = { x: event.clientX, y: event.clientY };
+      this.requestRender();
+      return;
+    }
+
+    if (!this.activeStroke) {
+      return;
+    }
+
+    const worldPoint = this.toWorld(event.offsetX, event.offsetY);
+    const points = this.activeStroke.path;
+    const lastPoint = points[points.length - 1];
+    const distance = Math.hypot(worldPoint.x - lastPoint.x, worldPoint.y - lastPoint.y);
+    if (distance > 1.5) {
+      points.push(worldPoint);
+      this.requestRender();
+    }
+  }
+
+  private handlePointerUp(event: PointerEvent): void {
+    this.canvas.releasePointerCapture(event.pointerId);
+    if (this.isPanning) {
+      this.isPanning = false;
+      this.lastPointer = null;
+      return;
+    }
+
+    if (!this.activeStroke) {
+      return;
+    }
+
+    if (this.activeStroke.path.length > 1) {
+      this.onStrokeComplete(this.activeStroke);
+    } else {
+      this.removeStroke(this.activeStroke.id);
+    }
+    this.activeStroke = null;
+  }
+
+  private handleWheel(event: WheelEvent): void {
+    event.preventDefault();
+    const scaleFactor = event.deltaY > 0 ? 0.9 : 1.1;
+    const newScale = Math.min(4, Math.max(0.2, this.camera.scale * scaleFactor));
+
+    const mouseWorld = this.toWorld(event.offsetX, event.offsetY);
+    this.camera.scale = newScale;
+    const newCenterScreen = this.toScreen(mouseWorld.x, mouseWorld.y);
+    const dx = event.offsetX - newCenterScreen.x;
+    const dy = event.offsetY - newCenterScreen.y;
+    this.camera.x -= dx / newScale;
+    this.camera.y -= dy / newScale;
+    this.requestRender();
+  }
+
+  private removeStroke(id: string): void {
+    this.strokes.delete(id);
+    this.strokeOrder = this.strokeOrder.filter((strokeId) => strokeId !== id);
+    this.requestRender();
+  }
+
+  private resize(): void {
+    const rect = this.canvas.getBoundingClientRect();
+    this.canvas.width = rect.width * window.devicePixelRatio;
+    this.canvas.height = rect.height * window.devicePixelRatio;
+    this.ctx.setTransform(window.devicePixelRatio, 0, 0, window.devicePixelRatio, 0, 0);
+    this.requestRender();
+  }
+
+  private toWorld(screenX: number, screenY: number): Point {
+    return {
+      x: (screenX - this.canvas.clientWidth / 2) / this.camera.scale + this.camera.x,
+      y: (screenY - this.canvas.clientHeight / 2) / this.camera.scale + this.camera.y,
+    };
+  }
+
+  private toScreen(worldX: number, worldY: number): Point {
+    return {
+      x: (worldX - this.camera.x) * this.camera.scale + this.canvas.clientWidth / 2,
+      y: (worldY - this.camera.y) * this.camera.scale + this.canvas.clientHeight / 2,
+    };
+  }
+
+  private requestRender(): void {
+    if (this.renderRequested) return;
+    this.renderRequested = true;
+    requestAnimationFrame(() => this.render());
+  }
+
+  private render(): void {
+    this.renderRequested = false;
+    const { width, height } = this.canvas;
+    this.ctx.save();
+    this.ctx.setTransform(window.devicePixelRatio, 0, 0, window.devicePixelRatio, 0, 0);
+    this.ctx.clearRect(0, 0, width, height);
+    this.ctx.restore();
+
+    this.drawGrid();
+
+    for (const strokeId of this.strokeOrder) {
+      const stroke = this.strokes.get(strokeId);
+      if (!stroke) continue;
+      this.drawStroke(stroke);
+    }
+
+    for (const patch of this.patches.values()) {
+      this.drawPatch(patch);
+    }
+  }
+
+  private drawGrid(): void {
+    const ctx = this.ctx;
+    const spacing = 64 * this.camera.scale;
+    if (spacing < 10) {
+      return;
+    }
+    ctx.save();
+    ctx.strokeStyle = '#e0e0e0';
+    ctx.lineWidth = 1;
+    ctx.setLineDash([4, 12]);
+
+    const width = this.canvas.clientWidth;
+    const height = this.canvas.clientHeight;
+    const origin = this.toScreen(0, 0);
+
+    for (let x = origin.x % spacing; x < width; x += spacing) {
+      ctx.beginPath();
+      ctx.moveTo(x, 0);
+      ctx.lineTo(x, height);
+      ctx.stroke();
+    }
+
+    for (let y = origin.y % spacing; y < height; y += spacing) {
+      ctx.beginPath();
+      ctx.moveTo(0, y);
+      ctx.lineTo(width, y);
+      ctx.stroke();
+    }
+
+    ctx.restore();
+  }
+
+  private drawStroke(stroke: Stroke): void {
+    const ctx = this.ctx;
+    ctx.save();
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
+    ctx.strokeStyle = stroke.color;
+    ctx.lineWidth = stroke.width * this.camera.scale;
+    ctx.beginPath();
+
+    const [first, ...rest] = stroke.path;
+    const firstScreen = this.toScreen(first.x, first.y);
+    ctx.moveTo(firstScreen.x, firstScreen.y);
+    for (const point of rest) {
+      const screen = this.toScreen(point.x, point.y);
+      ctx.lineTo(screen.x, screen.y);
+    }
+    ctx.stroke();
+
+    ctx.restore();
+  }
+
+  private drawPatch(patch: PatchOverlay): void {
+    const ctx = this.ctx;
+    ctx.save();
+    ctx.strokeStyle = patch.status === 'passed' ? '#6fcf97' : '#f2994a';
+    ctx.lineWidth = 2;
+    ctx.setLineDash([12, 8]);
+
+    this.drawBBox(patch.anchorRing.outer);
+    ctx.setLineDash([]);
+    ctx.globalAlpha = 0.1;
+    ctx.fillStyle = patch.status === 'passed' ? '#6fcf97' : '#f2994a';
+    this.fillBBox(patch.anchorRing.inner);
+    ctx.restore();
+  }
+
+  private drawBBox(bbox: BBox): void {
+    const ctx = this.ctx;
+    const topLeft = this.toScreen(bbox.x, bbox.y);
+    const bottomRight = this.toScreen(bbox.x + bbox.width, bbox.y + bbox.height);
+    ctx.beginPath();
+    ctx.rect(topLeft.x, topLeft.y, bottomRight.x - topLeft.x, bottomRight.y - topLeft.y);
+    ctx.stroke();
+  }
+
+  private fillBBox(bbox: BBox): void {
+    const ctx = this.ctx;
+    const topLeft = this.toScreen(bbox.x, bbox.y);
+    const bottomRight = this.toScreen(bbox.x + bbox.width, bbox.y + bbox.height);
+    ctx.beginPath();
+    ctx.rect(topLeft.x, topLeft.y, bottomRight.x - topLeft.x, bottomRight.y - topLeft.y);
+    ctx.fill();
+  }
+}

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,0 +1,169 @@
+import './styles/main.css';
+import { InfiniteCanvas } from './canvas/InfiniteCanvas';
+import { GameServiceClient } from './api/GameServiceClient';
+import { RealtimeClient } from './ws/RealtimeClient';
+import { ObjectPanel } from './ui/ObjectPanel';
+import { Toolbar } from './ui/Toolbar';
+import type { AnchorRing, RoomSnapshot, Stroke } from './types';
+
+const backendBase = import.meta.env.VITE_BACKEND_URL ?? 'http://localhost:8000/api';
+const realtimeBase = import.meta.env.VITE_REALTIME_URL ?? 'ws://localhost:9001';
+
+const appRoot = document.querySelector<HTMLDivElement>('#app');
+if (!appRoot) {
+  throw new Error('App root not found');
+}
+
+let statusTimeout: number | undefined;
+
+const toolbar = new Toolbar();
+const objectPanel = new ObjectPanel();
+const content = document.createElement('div');
+content.className = 'app-content';
+const canvasContainer = document.createElement('div');
+canvasContainer.className = 'canvas-container';
+const canvasEl = document.createElement('canvas');
+canvasContainer.appendChild(canvasEl);
+content.appendChild(canvasContainer);
+content.appendChild(objectPanel.element);
+
+const statusBanner = document.createElement('div');
+statusBanner.className = 'status-banner';
+statusBanner.style.display = 'none';
+statusBanner.textContent = 'Ready';
+canvasContainer.appendChild(statusBanner);
+
+appRoot.appendChild(toolbar.element);
+appRoot.appendChild(content);
+
+const userId = getOrCreateUserId();
+const gameClient = new GameServiceClient(backendBase);
+
+(async () => {
+  const roomId = await ensureRoom(gameClient, userId);
+  const snapshot = await loadSnapshot(gameClient, roomId, userId);
+
+  const canvas = new InfiniteCanvas(canvasEl, handleStrokeComplete, userId);
+  const strokeRegistry = new Map<string, Stroke>();
+
+  const realtimeClient = new RealtimeClient(realtimeBase, roomId, userId);
+  realtimeClient.on('stroke', (incoming) => {
+    if (strokeRegistry.has(incoming.id)) return;
+    strokeRegistry.set(incoming.id, incoming);
+    canvas.addStroke(incoming);
+    objectPanel.addStroke(incoming);
+  });
+
+  realtimeClient.on('turn', (payload) => {
+    const patch = payload.patch as { anchor?: AnchorRing } | undefined;
+    if (payload.status === 'ai_completed' || payload.status === 'AI_COMPLETED') {
+      const anchorRing = (patch?.anchor ?? patch) as AnchorRing | undefined;
+      if (anchorRing) {
+        canvas.showPatch(payload.turnId, anchorRing, payload.safetyStatus ?? 'passed');
+        showStatus(`AI added a storybook detail (turn ${payload.sequence})`);
+      }
+    } else if (payload.status === 'blocked') {
+      showStatus('AI turn blocked for safety review');
+    }
+  });
+
+  realtimeClient.connect();
+
+  toolbar.onBrushChange(({ color, width }) => {
+    canvas.setBrush(color, width);
+  });
+  toolbar.onResetView(() => {
+    canvas.setCamera({ x: 0, y: 0 }, 1);
+  });
+
+  objectPanel.setCommitHandler(async ({ strokeIds, label }) => {
+    try {
+      await gameClient.commitObject(roomId, userId, strokeIds, label || undefined);
+      showStatus('Object committed! Waiting for AI response…');
+    } catch (error) {
+      console.error(error);
+      showStatus('Failed to commit object');
+    }
+  });
+
+  function showStatus(message: string): void {
+    statusBanner.textContent = message;
+    statusBanner.style.display = 'flex';
+    if (statusTimeout) {
+      window.clearTimeout(statusTimeout);
+    }
+    statusTimeout = window.setTimeout(() => {
+      statusBanner.style.display = 'none';
+      statusTimeout = undefined;
+    }, 3000);
+  }
+
+  function addSnapshot(snapshot: RoomSnapshot): void {
+    for (const stroke of snapshot.strokes) {
+      const normalised: Stroke = {
+        id: stroke.id,
+        authorId: stroke.author_id,
+        color: stroke.color,
+        width: stroke.width,
+        path: stroke.path,
+        objectId: stroke.object_id,
+        ts: stroke.ts,
+      };
+      strokeRegistry.set(normalised.id, normalised);
+      canvas.addStroke(normalised);
+      objectPanel.addStroke(normalised);
+    }
+  }
+
+  addSnapshot(snapshot);
+
+  async function handleStrokeComplete(stroke: Stroke): Promise<void> {
+    const tempId = stroke.id;
+    stroke.authorId = userId;
+    strokeRegistry.set(tempId, stroke);
+    objectPanel.addStroke(stroke);
+    realtimeClient.sendStroke(stroke);
+    try {
+      const persisted = await gameClient.createStroke(roomId, stroke);
+      strokeRegistry.delete(tempId);
+      strokeRegistry.set(persisted.id, persisted);
+      canvas.confirmStroke(tempId, persisted);
+      objectPanel.confirmStroke(tempId, persisted);
+    } catch (error) {
+      console.error('Failed to persist stroke', error);
+      showStatus('Failed to sync stroke');
+    }
+  }
+})();
+
+function getOrCreateUserId(): string {
+  const key = 'kids-canvas-user-id';
+  const existing = window.localStorage.getItem(key);
+  if (existing) {
+    return existing;
+  }
+  const generated = crypto.randomUUID();
+  window.localStorage.setItem(key, generated);
+  return generated;
+}
+
+async function ensureRoom(client: GameServiceClient, userId: string): Promise<string> {
+  const currentHash = window.location.hash.replace('#', '');
+  if (currentHash) {
+    return currentHash;
+  }
+  const created = await client.createRoom('Storybook Room', userId);
+  const roomId = created.room.id;
+  window.location.hash = roomId;
+  return roomId;
+}
+
+async function loadSnapshot(client: GameServiceClient, roomId: string, userId: string): Promise<RoomSnapshot> {
+  try {
+    const snapshot = await client.joinRoom(roomId, userId);
+    return snapshot;
+  } catch (error) {
+    console.error('Failed to join room', error);
+    throw error;
+  }
+}

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -1,0 +1,180 @@
+:root {
+  color-scheme: light;
+  font-family: 'Nunito', 'Segoe UI', sans-serif;
+}
+
+body {
+  margin: 0;
+  background: #f4f7fb;
+  color: #1f2933;
+}
+
+#app {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1.5rem;
+  background: linear-gradient(90deg, #ffd6e0, #d7f5ff);
+  box-shadow: 0 2px 8px rgba(31, 41, 51, 0.1);
+}
+
+.toolbar h1 {
+  margin: 0;
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: #2f4858;
+}
+
+.toolbar__controls {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.toolbar__label {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.75rem;
+  color: #3d5667;
+  gap: 0.25rem;
+}
+
+.toolbar button {
+  border: none;
+  background: #2f80ed;
+  color: white;
+  border-radius: 999px;
+  padding: 0.4rem 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.toolbar button:hover {
+  background: #1366d6;
+}
+
+.app-content {
+  flex: 1;
+  display: flex;
+  overflow: hidden;
+}
+
+.canvas-container {
+  flex: 1;
+  position: relative;
+  background: #ffffff;
+  box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.05);
+}
+
+.canvas-container canvas {
+  width: 100%;
+  height: 100%;
+  touch-action: none;
+  cursor: crosshair;
+}
+
+.object-panel {
+  width: 280px;
+  background: rgba(255, 255, 255, 0.9);
+  border-left: 1px solid rgba(47, 72, 88, 0.1);
+  display: flex;
+  flex-direction: column;
+  backdrop-filter: blur(8px);
+}
+
+.object-panel__header {
+  padding: 1rem;
+  border-bottom: 1px solid rgba(47, 72, 88, 0.1);
+}
+
+.object-panel__header h2 {
+  margin: 0;
+  font-size: 1rem;
+  color: #2f4858;
+}
+
+.object-panel__list {
+  flex: 1;
+  margin: 0;
+  padding: 0.5rem 1rem;
+  list-style: none;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.object-panel__item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  border-radius: 0.75rem;
+  background: rgba(223, 242, 255, 0.6);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.object-panel__item--selected {
+  box-shadow: 0 8px 16px rgba(47, 72, 88, 0.15);
+  transform: translateY(-2px);
+}
+
+.object-panel__swatch {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 2px solid rgba(0, 0, 0, 0.05);
+}
+
+.object-panel__controls {
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  border-top: 1px solid rgba(47, 72, 88, 0.1);
+}
+
+.object-panel__controls input[type='text'] {
+  border-radius: 0.75rem;
+  border: 1px solid rgba(47, 72, 88, 0.2);
+  padding: 0.6rem 0.75rem;
+  font-size: 0.9rem;
+}
+
+.object-panel__controls button {
+  border-radius: 999px;
+  padding: 0.6rem;
+  border: none;
+  background: linear-gradient(135deg, #ff9a9e, #fad0c4);
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.object-panel__controls button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 16px rgba(250, 208, 196, 0.6);
+}
+
+.status-banner {
+  position: absolute;
+  bottom: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(47, 72, 88, 0.85);
+  color: white;
+  padding: 0.6rem 1.5rem;
+  border-radius: 999px;
+  font-size: 0.9rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  box-shadow: 0 12px 24px rgba(47, 72, 88, 0.2);
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,0 +1,100 @@
+export type Point = {
+  x: number;
+  y: number;
+};
+
+export type BBox = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+export type AnchorRing = {
+  inner: BBox;
+  outer: BBox;
+};
+
+export type Stroke = {
+  id: string;
+  authorId: string;
+  color: string;
+  width: number;
+  path: Point[];
+  objectId?: string | null;
+  ts?: string;
+  pending?: boolean;
+};
+
+export type CanvasObject = {
+  id: string;
+  ownerId: string;
+  label?: string | null;
+  status: string;
+  bbox: BBox;
+  anchorRing: AnchorRing;
+  createdAt?: string;
+};
+
+export type TurnEventPayload = {
+  turnId: string;
+  sequence: number;
+  status: string;
+  safetyStatus?: string;
+  patch?: Record<string, unknown>;
+  reason?: string;
+};
+
+export type MessageEnvelope<T = Record<string, unknown>> = {
+  topic: 'stroke' | 'object' | 'turn' | 'system';
+  roomId: string;
+  timestamp: string;
+  payload: T;
+  action?: string;
+};
+
+export type RoomSnapshot = {
+  room: {
+    id: string;
+    name: string;
+    turn_seq: number;
+    created_at: string;
+  };
+  member: {
+    room_id: string;
+    user_id: string;
+    role: string;
+    joined_at: string;
+  };
+  members: Array<{
+    room_id: string;
+    user_id: string;
+    role: string;
+    joined_at: string;
+  }>;
+  strokes: Array<{
+    id: string;
+    room_id: string;
+    author_id: string;
+    color: string;
+    width: number;
+    ts: string;
+    path: Point[];
+    object_id: string | null;
+  }>;
+  objects: Array<{
+    id: string;
+    owner_id: string;
+    label?: string | null;
+    status: string;
+    bbox: BBox;
+    anchor_ring: AnchorRing;
+  }>;
+  turns: Array<{
+    id: string;
+    sequence: number;
+    status: string;
+    current_actor: string;
+    source_object_id: string;
+  }>;
+};

--- a/frontend/src/ui/ObjectPanel.ts
+++ b/frontend/src/ui/ObjectPanel.ts
@@ -1,0 +1,135 @@
+import type { Stroke } from '../types';
+
+type CommitHandler = (selection: { strokeIds: string[]; label: string }) => void;
+
+type StrokeMeta = {
+  id: string;
+  color: string;
+  width: number;
+  selected: boolean;
+};
+
+export class ObjectPanel {
+  readonly element: HTMLElement;
+  private readonly list: HTMLElement;
+  private readonly labelInput: HTMLInputElement;
+  private readonly commitButton: HTMLButtonElement;
+  private strokes = new Map<string, StrokeMeta>();
+  private commitHandler: CommitHandler | null = null;
+
+  constructor() {
+    this.element = document.createElement('section');
+    this.element.className = 'object-panel';
+
+    const header = document.createElement('div');
+    header.className = 'object-panel__header';
+    header.innerHTML = '<h2>Objects</h2>';
+    this.element.appendChild(header);
+
+    this.list = document.createElement('ul');
+    this.list.className = 'object-panel__list';
+    this.element.appendChild(this.list);
+
+    const controls = document.createElement('div');
+    controls.className = 'object-panel__controls';
+    this.labelInput = document.createElement('input');
+    this.labelInput.type = 'text';
+    this.labelInput.placeholder = 'Describe this object (optional)';
+    this.commitButton = document.createElement('button');
+    this.commitButton.textContent = 'Commit Object';
+    this.commitButton.addEventListener('click', () => this.handleCommit());
+
+    controls.appendChild(this.labelInput);
+    controls.appendChild(this.commitButton);
+    this.element.appendChild(controls);
+  }
+
+  setCommitHandler(handler: CommitHandler): void {
+    this.commitHandler = handler;
+  }
+
+  addStroke(stroke: Stroke): void {
+    if (this.strokes.has(stroke.id)) {
+      return;
+    }
+    this.strokes.set(stroke.id, {
+      id: stroke.id,
+      color: stroke.color,
+      width: stroke.width,
+      selected: false,
+    });
+    this.renderList();
+  }
+
+  confirmStroke(tempId: string, persisted: Stroke): void {
+    const entry = this.strokes.get(tempId);
+    if (!entry) {
+      this.addStroke(persisted);
+      return;
+    }
+    this.strokes.delete(tempId);
+    this.strokes.set(persisted.id, {
+      id: persisted.id,
+      color: persisted.color,
+      width: persisted.width,
+      selected: entry.selected,
+    });
+    this.renderList();
+  }
+
+  setSelection(strokeIds: string[]): void {
+    for (const entry of this.strokes.values()) {
+      entry.selected = strokeIds.includes(entry.id);
+    }
+    this.renderList();
+  }
+
+  private handleCommit(): void {
+    if (!this.commitHandler) {
+      return;
+    }
+    const selected = [...this.strokes.values()].filter((stroke) => stroke.selected).map((stroke) => stroke.id);
+    if (selected.length === 0) {
+      return;
+    }
+    const label = this.labelInput.value.trim();
+    this.commitHandler({ strokeIds: selected, label });
+    this.labelInput.value = '';
+    this.clearSelection();
+  }
+
+  private clearSelection(): void {
+    for (const entry of this.strokes.values()) {
+      entry.selected = false;
+    }
+    this.renderList();
+  }
+
+  private renderList(): void {
+    this.list.innerHTML = '';
+    for (const stroke of this.strokes.values()) {
+      const item = document.createElement('li');
+      item.className = 'object-panel__item';
+      if (stroke.selected) {
+        item.classList.add('object-panel__item--selected');
+      }
+      const swatch = document.createElement('span');
+      swatch.className = 'object-panel__swatch';
+      swatch.style.backgroundColor = stroke.color;
+      const label = document.createElement('span');
+      label.textContent = stroke.id.slice(0, 6);
+      const toggle = document.createElement('input');
+      toggle.type = 'checkbox';
+      toggle.checked = stroke.selected;
+      toggle.addEventListener('change', () => {
+        stroke.selected = toggle.checked;
+        this.renderList();
+      });
+
+      item.appendChild(toggle);
+      item.appendChild(swatch);
+      item.appendChild(label);
+      this.list.appendChild(item);
+    }
+  }
+}

--- a/frontend/src/ui/Toolbar.ts
+++ b/frontend/src/ui/Toolbar.ts
@@ -1,0 +1,70 @@
+type BrushChangeHandler = (options: { color: string; width: number }) => void;
+
+type ActionHandler = () => void;
+
+export class Toolbar {
+  readonly element: HTMLElement;
+  private readonly colorInput: HTMLInputElement;
+  private readonly widthInput: HTMLInputElement;
+  private readonly resetViewButton: HTMLButtonElement;
+  private brushHandler: BrushChangeHandler | null = null;
+  private resetHandler: ActionHandler | null = null;
+
+  constructor() {
+    this.element = document.createElement('header');
+    this.element.className = 'toolbar';
+
+    const title = document.createElement('h1');
+    title.textContent = 'Infinite Kids Canvas';
+    this.element.appendChild(title);
+
+    const controls = document.createElement('div');
+    controls.className = 'toolbar__controls';
+
+    this.colorInput = document.createElement('input');
+    this.colorInput.type = 'color';
+    this.colorInput.value = '#2f80ed';
+    this.colorInput.addEventListener('input', () => this.emitBrushChange());
+
+    this.widthInput = document.createElement('input');
+    this.widthInput.type = 'range';
+    this.widthInput.min = '2';
+    this.widthInput.max = '24';
+    this.widthInput.value = '6';
+    this.widthInput.addEventListener('input', () => this.emitBrushChange());
+
+    this.resetViewButton = document.createElement('button');
+    this.resetViewButton.textContent = 'Center Canvas';
+    this.resetViewButton.addEventListener('click', () => this.resetHandler?.());
+
+    controls.appendChild(this.createControlLabel('Color', this.colorInput));
+    controls.appendChild(this.createControlLabel('Size', this.widthInput));
+    controls.appendChild(this.resetViewButton);
+    this.element.appendChild(controls);
+  }
+
+  onBrushChange(handler: BrushChangeHandler): void {
+    this.brushHandler = handler;
+    this.emitBrushChange();
+  }
+
+  onResetView(handler: ActionHandler): void {
+    this.resetHandler = handler;
+  }
+
+  private emitBrushChange(): void {
+    if (!this.brushHandler) return;
+    this.brushHandler({
+      color: this.colorInput.value,
+      width: Number(this.widthInput.value),
+    });
+  }
+
+  private createControlLabel(label: string, input: HTMLElement): HTMLElement {
+    const wrapper = document.createElement('label');
+    wrapper.className = 'toolbar__label';
+    wrapper.textContent = label;
+    wrapper.appendChild(input);
+    return wrapper;
+  }
+}

--- a/frontend/src/ws/RealtimeClient.ts
+++ b/frontend/src/ws/RealtimeClient.ts
@@ -1,0 +1,176 @@
+import type { MessageEnvelope, Stroke, TurnEventPayload } from '../types';
+
+type EventHandler<T> = (payload: T) => void;
+
+type TopicHandlerMap = {
+  stroke: Set<EventHandler<Stroke>>;
+  object: Set<EventHandler<Record<string, unknown>>>;
+  turn: Set<EventHandler<TurnEventPayload>>;
+  system: Set<EventHandler<Record<string, unknown>>>;
+};
+
+const createHandlerMap = (): TopicHandlerMap => ({
+  stroke: new Set(),
+  object: new Set(),
+  turn: new Set(),
+  system: new Set(),
+});
+
+export class RealtimeClient {
+  private socket: WebSocket | null = null;
+  private handlers: TopicHandlerMap = createHandlerMap();
+  private reconnectAttempts = 0;
+  private heartbeatInterval: number | undefined;
+
+  constructor(
+    private readonly url: string,
+    private readonly roomId: string,
+    private readonly userId: string,
+  ) {}
+
+  connect(): void {
+    if (this.socket && (this.socket.readyState === WebSocket.OPEN || this.socket.readyState === WebSocket.CONNECTING)) {
+      return;
+    }
+    this.socket = new WebSocket(this.url);
+    this.socket.addEventListener('open', () => {
+      this.reconnectAttempts = 0;
+      this.sendSystem('join', { roomId: this.roomId, userId: this.userId });
+      this.startHeartbeat();
+    });
+
+    this.socket.addEventListener('message', (event) => {
+      try {
+        const envelope = JSON.parse(event.data) as MessageEnvelope;
+        this.dispatch(envelope);
+      } catch (error) {
+        console.warn('Failed to parse realtime message', error);
+      }
+    });
+
+    this.socket.addEventListener('close', () => {
+      this.stopHeartbeat();
+      this.scheduleReconnect();
+    });
+
+    this.socket.addEventListener('error', () => {
+      this.socket?.close();
+    });
+  }
+
+  on(topic: 'stroke', handler: EventHandler<Stroke>): void;
+  on(topic: 'object', handler: EventHandler<Record<string, unknown>>): void;
+  on(topic: 'turn', handler: EventHandler<TurnEventPayload>): void;
+  on(topic: 'system', handler: EventHandler<Record<string, unknown>>): void;
+  on(topic: keyof TopicHandlerMap, handler: EventHandler<unknown>): void {
+    (this.handlers[topic] as Set<EventHandler<unknown>>).add(handler as EventHandler<unknown>);
+  }
+
+  off(topic: 'stroke', handler: EventHandler<Stroke>): void;
+  off(topic: 'object', handler: EventHandler<Record<string, unknown>>): void;
+  off(topic: 'turn', handler: EventHandler<TurnEventPayload>): void;
+  off(topic: 'system', handler: EventHandler<Record<string, unknown>>): void;
+  off(topic: keyof TopicHandlerMap, handler: EventHandler<unknown>): void {
+    (this.handlers[topic] as Set<EventHandler<unknown>>).delete(handler as EventHandler<unknown>);
+  }
+
+  sendStroke(stroke: Stroke): void {
+    this.send({
+      topic: 'stroke',
+      roomId: this.roomId,
+      timestamp: new Date().toISOString(),
+      payload: {
+        id: stroke.id,
+        roomId: this.roomId,
+        authorId: stroke.authorId,
+        color: stroke.color,
+        width: stroke.width,
+        path: stroke.path,
+        objectId: stroke.objectId ?? null,
+      },
+    });
+  }
+
+  private dispatch(envelope: MessageEnvelope): void {
+    const set = this.handlers[envelope.topic as keyof TopicHandlerMap];
+    if (!set) return;
+    const payload = envelope.payload;
+    switch (envelope.topic) {
+      case 'stroke':
+        for (const handler of set) {
+          handler({
+            id: String(payload['id']),
+            authorId: String(payload['authorId'] ?? payload['author_id'] ?? ''),
+            color: String(payload['color'] ?? '#000000'),
+            width: Number(payload['width'] ?? 1),
+            path: Array.isArray(payload['path']) ? (payload['path'] as Stroke['path']) : [],
+            objectId: (payload['objectId'] ?? payload['object_id'] ?? null) as string | null,
+            ts: typeof payload['ts'] === 'string' ? (payload['ts'] as string) : undefined,
+          });
+        }
+        break;
+      case 'turn':
+        for (const handler of set) {
+          handler({
+            turnId: String(payload['turnId'] ?? payload['turn_id'] ?? ''),
+            sequence: Number(payload['sequence'] ?? 0),
+            status: String(payload['status'] ?? ''),
+            safetyStatus: payload['safetyStatus']?.toString(),
+            patch: (payload['patch'] as Record<string, unknown>) ?? undefined,
+            reason: payload['reason']?.toString(),
+          });
+        }
+        break;
+      case 'system':
+        if (envelope.action === 'pong') {
+          return;
+        }
+        for (const handler of set) {
+          handler(payload);
+        }
+        break;
+      case 'object':
+      default:
+        for (const handler of set) {
+          handler(payload);
+        }
+    }
+  }
+
+  private send(envelope: MessageEnvelope): void {
+    if (!this.socket || this.socket.readyState !== WebSocket.OPEN) {
+      return;
+    }
+    this.socket.send(JSON.stringify(envelope));
+  }
+
+  private sendSystem(action: string, payload: Record<string, unknown>): void {
+    this.send({
+      topic: 'system',
+      action,
+      roomId: this.roomId,
+      timestamp: new Date().toISOString(),
+      payload,
+    });
+  }
+
+  private scheduleReconnect(): void {
+    this.reconnectAttempts += 1;
+    const delay = Math.min(5000, 500 * this.reconnectAttempts);
+    setTimeout(() => this.connect(), delay);
+  }
+
+  private startHeartbeat(): void {
+    this.stopHeartbeat();
+    this.heartbeatInterval = window.setInterval(() => {
+      this.sendSystem('ping', {});
+    }, 10000);
+  }
+
+  private stopHeartbeat(): void {
+    if (this.heartbeatInterval) {
+      window.clearInterval(this.heartbeatInterval);
+      this.heartbeatInterval = undefined;
+    }
+  }
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "jsx": "preserve",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "types": ["vite/client"],
+    "lib": ["ES2020", "DOM", "DOM.Iterable"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  root: '.',
+  build: {
+    outDir: 'dist',
+    sourcemap: true
+  }
+});

--- a/realtime/src/index.ts
+++ b/realtime/src/index.ts
@@ -1,25 +1,26 @@
 import { WebSocketServer, WebSocket } from 'ws';
 import { loadConfig } from './config.js';
 
-interface StrokeMessage {
-  type: 'stroke';
-  payload: Record<string, unknown>;
-}
+type Topic = 'stroke' | 'object' | 'turn' | 'system';
 
-interface ObjectMessage {
-  type: 'object';
-  payload: Record<string, unknown>;
-}
+type MessageEnvelope<T = Record<string, unknown>> = {
+  topic: Topic;
+  roomId: string;
+  timestamp: string;
+  payload: T;
+  action?: string;
+};
 
-interface TurnMessage {
-  type: 'turn';
-  payload: Record<string, unknown>;
-}
-
-type RoomMessage = StrokeMessage | ObjectMessage | TurnMessage;
+type SystemPayload = {
+  roomId?: string;
+  userId?: string;
+  message?: string;
+};
 
 type ConnectionContext = {
   roomId: string;
+  userId?: string;
+  joinedAt: number;
 };
 
 const config = loadConfig();
@@ -29,12 +30,20 @@ const server = new WebSocketServer({ host: config.host, port: config.port });
 const rooms = new Map<string, Set<WebSocket>>();
 const context = new WeakMap<WebSocket, ConnectionContext>();
 
-const joinRoom = (socket: WebSocket, roomId: string) => {
+const nowIso = () => new Date().toISOString();
+
+const sendEnvelope = <T>(socket: WebSocket, envelope: MessageEnvelope<T>) => {
+  if (socket.readyState === WebSocket.OPEN) {
+    socket.send(JSON.stringify(envelope));
+  }
+};
+
+const joinRoom = (socket: WebSocket, roomId: string, userId?: string) => {
   if (!rooms.has(roomId)) {
     rooms.set(roomId, new Set());
   }
   rooms.get(roomId)?.add(socket);
-  context.set(socket, { roomId });
+  context.set(socket, { roomId, userId, joinedAt: Date.now() });
 };
 
 const leaveRoom = (socket: WebSocket) => {
@@ -48,7 +57,7 @@ const leaveRoom = (socket: WebSocket) => {
   context.delete(socket);
 };
 
-const broadcast = (roomId: string, message: RoomMessage, sender?: WebSocket) => {
+const broadcast = (roomId: string, message: MessageEnvelope, sender?: WebSocket) => {
   const roomSockets = rooms.get(roomId);
   if (!roomSockets) return;
   const raw = JSON.stringify(message);
@@ -59,26 +68,111 @@ const broadcast = (roomId: string, message: RoomMessage, sender?: WebSocket) => 
   }
 };
 
+const sendError = (socket: WebSocket, message: string, details: Record<string, unknown> = {}) => {
+  sendEnvelope(socket, {
+    topic: 'system',
+    roomId: details['roomId']?.toString() ?? '',
+    action: 'error',
+    timestamp: nowIso(),
+    payload: { message, ...details },
+  });
+};
+
+const handleSystemMessage = (socket: WebSocket, envelope: MessageEnvelope<SystemPayload>) => {
+  const action = envelope.action ?? 'ping';
+  switch (action) {
+    case 'join':
+    case 'resume': {
+      const { roomId, userId } = envelope.payload;
+      if (!roomId) {
+        sendError(socket, 'roomId is required to join');
+        return;
+      }
+      joinRoom(socket, roomId, userId);
+      sendEnvelope(socket, {
+        topic: 'system',
+        action: 'ack',
+        roomId,
+        timestamp: nowIso(),
+        payload: { message: 'joined', roomId, userId },
+      });
+      break;
+    }
+    case 'leave': {
+      leaveRoom(socket);
+      sendEnvelope(socket, {
+        topic: 'system',
+        action: 'ack',
+        roomId: envelope.roomId,
+        timestamp: nowIso(),
+        payload: { message: 'left' },
+      });
+      break;
+    }
+    case 'ping': {
+      const meta = context.get(socket);
+      sendEnvelope(socket, {
+        topic: 'system',
+        action: 'pong',
+        roomId: meta?.roomId ?? envelope.roomId,
+        timestamp: nowIso(),
+        payload: { message: 'pong' },
+      });
+      break;
+    }
+    default: {
+      sendError(socket, 'Unsupported system action', { action });
+    }
+  }
+};
+
+const normaliseEnvelope = (incoming: Record<string, unknown>, socket: WebSocket): MessageEnvelope => {
+  const topic = incoming['topic'];
+  if (topic !== 'stroke' && topic !== 'object' && topic !== 'turn' && topic !== 'system') {
+    throw new Error('Unknown topic');
+  }
+  const payload = incoming['payload'];
+  if (typeof payload !== 'object' || payload === null) {
+    throw new Error('payload must be an object');
+  }
+  const meta = context.get(socket);
+  const roomIdValue = (incoming['roomId'] ?? (payload as Record<string, unknown>)['roomId']) as string | undefined;
+  const roomId = roomIdValue ?? meta?.roomId;
+  if (!roomId) {
+    throw new Error('roomId missing from message');
+  }
+  const timestamp = typeof incoming['timestamp'] === 'string' ? (incoming['timestamp'] as string) : nowIso();
+  return {
+    topic,
+    action: typeof incoming['action'] === 'string' ? (incoming['action'] as string) : undefined,
+    roomId,
+    timestamp,
+    payload: payload as Record<string, unknown>,
+  };
+};
+
 server.on('connection', (socket) => {
   socket.on('message', (data) => {
     try {
-      const parsed = JSON.parse(data.toString()) as RoomMessage & {
-        roomId?: string;
-        topic?: string;
+      const parsed = JSON.parse(data.toString()) as Record<string, unknown>;
+      const envelope = normaliseEnvelope(parsed, socket);
+      if (envelope.topic === 'system') {
+        handleSystemMessage(socket, envelope as MessageEnvelope<SystemPayload>);
+        return;
+      }
+      const meta = context.get(socket);
+      if (!meta || meta.roomId !== envelope.roomId) {
+        sendError(socket, 'Join the room before sending events', { roomId: envelope.roomId });
+        return;
+      }
+      const message = {
+        ...envelope,
+        timestamp: nowIso(),
       };
-      if (!parsed?.payload || typeof parsed.payload !== 'object') {
-        return;
-      }
-      const roomId = parsed.payload['roomId'] ?? parsed['roomId'];
-      if (typeof roomId !== 'string') {
-        return;
-      }
-      if (!context.has(socket)) {
-        joinRoom(socket, roomId);
-      }
-      broadcast(roomId, parsed, socket);
+      broadcast(envelope.roomId, message, socket);
     } catch (error) {
       console.error('Invalid message received', error);
+      sendError(socket, 'Invalid message format');
     }
   });
 


### PR DESCRIPTION
## Summary
- add room creation/join snapshots, stroke APIs, and supporting services with tests to cover the collaborative data loop
- introduce a background turn processor that calls the AI agent, updates state, and emits structured realtime events while tightening the redis helpers and app lifecycle
- refactor the websocket gateway message format and deliver a TypeScript canvas prototype with toolbar, object panel, websocket sync, and AI patch overlays; update documentation to mark phase completion

## Testing
- `pip install -e .[dev]` *(fails: package index blocked by proxy – cannot install build deps)*
- `pytest -q` *(fails: ModuleNotFoundError for httpx because dependencies could not be installed)*
- `npm install` *(fails: registry access forbidden by proxy policy)*

------
https://chatgpt.com/codex/tasks/task_e_68e65318a184832883cb74d6544aec5b