### PR TITLE
Harden realtime gateway connection handling

### DIFF
--- a/docs/prototype_todo.md
+++ b/docs/prototype_todo.md
@@ -13,6 +13,7 @@
 ### Realtime Gateway
 - 已有基於 `ws` 套件的 WebSocket 伺服器，能按房間維持連線、接收 stroke/object/turn 主題訊息並轉發給其他客戶端。【F:realtime/src/index.ts†L1-L83】
 - Heartbeat/ping 機制與基本環境設定載入已就緒，但尚未串接後端或持久化訊息。【F:realtime/src/index.ts†L85-L98】【F:realtime/src/config.ts†L1-L10】
+- 完成連線強韌性優化：新增 payload 大小防護、速率限制、presence 廣播與超時終止閒置連線，並提供環境變數調校的設定檔匯入。【F:realtime/src/index.ts†L19-L218】【F:realtime/src/config.ts†L1-L28】
 
 ### AI Agent
 - FastAPI 服務已建立 `/generate` 端點，並透過 `PatchGenerationPipeline` 回傳童話風格的佔位 patch payload，可作為整合時的假資料來源。【F:ai_agent/app/main.py†L1-L17】【F:ai_agent/app/pipelines/patch_generation.py†L1-L18】

--- a/realtime/src/config.ts
+++ b/realtime/src/config.ts
@@ -1,11 +1,34 @@
+export interface RateLimitConfig {
+  burst: number;
+  refillIntervalMs: number;
+}
+
 export interface GatewayConfig {
   host: string;
   port: number;
   heartbeatIntervalMs: number;
+  heartbeatToleranceMs: number;
+  maxPayloadBytes: number;
+  rateLimit: RateLimitConfig;
 }
+
+const numberFromEnv = (key: string, fallback: number): number => {
+  const value = process.env[key];
+  if (value === undefined) {
+    return fallback;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+};
 
 export const loadConfig = (): GatewayConfig => ({
   host: process.env.GATEWAY_HOST ?? '0.0.0.0',
-  port: Number(process.env.GATEWAY_PORT ?? 8080),
-  heartbeatIntervalMs: Number(process.env.GATEWAY_HEARTBEAT_MS ?? 15000),
+  port: numberFromEnv('GATEWAY_PORT', 8080),
+  heartbeatIntervalMs: numberFromEnv('GATEWAY_HEARTBEAT_MS', 15000),
+  heartbeatToleranceMs: numberFromEnv('GATEWAY_HEARTBEAT_TOLERANCE_MS', 45000),
+  maxPayloadBytes: numberFromEnv('GATEWAY_MAX_PAYLOAD_BYTES', 256 * 1024),
+  rateLimit: {
+    burst: numberFromEnv('GATEWAY_RATE_LIMIT_BURST', 40),
+    refillIntervalMs: numberFromEnv('GATEWAY_RATE_LIMIT_REFILL_MS', 1000),
+  },
 });


### PR DESCRIPTION
## Summary
- add payload size checks, per-connection rate limiting, and presence broadcasts to the realtime gateway
- terminate stale sockets based on ping/pong heartbeats and expose tuning knobs via config
- document the realtime gateway hardening work in the prototype TODO

## Testing
- npm run lint

## Risks
- tightening gateway constraints could throttle legitimate clients if the default rate limit is misconfigured

------
https://chatgpt.com/codex/tasks/task_e_68e7964c0e60832897bdf094ef65cd7d