### PR TITLE
Ensure stroke endpoints validate responses and broadcast correctly

### DIFF
--- a/backend/app/api/routes/strokes.py
+++ b/backend/app/api/routes/strokes.py
@@ -7,7 +7,12 @@ from fastapi import APIRouter, Depends
 
 from ...core.database import DatabaseSession, get_db_session
 from ...core.redis import RedisWrapper, get_redis
-from ...schemas.strokes import StrokeBatchResponse, StrokeCreatePayload, StrokeCreateResponse
+from ...schemas.strokes import (
+    StrokeBatchResponse,
+    StrokeCreatePayload,
+    StrokeCreateResponse,
+    StrokeSchema,
+)
 from ...services.strokes import create_stroke, list_strokes as list_strokes_service
 
 router = APIRouter(prefix="/rooms/{room_id}/strokes", tags=["strokes"])
@@ -29,7 +34,7 @@ async def create_stroke_endpoint(
         color=payload.color,
         width=payload.width,
     )
-    return StrokeCreateResponse(stroke=stroke)
+    return StrokeCreateResponse(stroke=StrokeSchema.model_validate(stroke))
 
 
 @router.get("", response_model=StrokeBatchResponse)
@@ -38,4 +43,6 @@ async def list_strokes(
     session: DatabaseSession = Depends(get_db_session),
 ) -> StrokeBatchResponse:
     strokes = list_strokes_service(session, room_id=room_id)
-    return StrokeBatchResponse(strokes=list(strokes))
+    return StrokeBatchResponse(
+        strokes=[StrokeSchema.model_validate(stroke) for stroke in strokes]
+    )

--- a/backend/app/schemas/strokes.py
+++ b/backend/app/schemas/strokes.py
@@ -10,6 +10,8 @@ from pydantic.config import ConfigDict
 
 
 class PointSchema(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
     x: float
     y: float
 

--- a/backend/app/services/strokes.py
+++ b/backend/app/services/strokes.py
@@ -13,6 +13,7 @@ from ..models import Point, Room, Stroke
 from .audit import record_audit_event
 
 WS_EVENT_STREAM = "ws:events"
+OBJECT_EVENT_STREAM = "ws:object-events"
 
 
 def _ensure_room(session: DatabaseSession, room_id: UUID) -> Room:
@@ -99,7 +100,7 @@ async def broadcast_object_event(
     payload: dict[str, object],
 ) -> None:
     await redis.enqueue_json(
-        WS_EVENT_STREAM,
+        OBJECT_EVENT_STREAM,
         {
             "topic": "object",
             "roomId": str(room_id),


### PR DESCRIPTION
## Summary
- ensure stroke creation and listing endpoints return validated schemas for clients
- allow stroke point schemas to hydrate from dataclass instances written by the service layer
- separate object websocket broadcasts from the shared stroke stream to avoid mixing events

## Testing
- pytest -q

## Risks
- Low: websocket consumers must subscribe to the new object event stream name

------
https://chatgpt.com/codex/tasks/task_e_68ecfe7e75d88328965c4581fdff71fb