### PR TITLE
docs: refresh prototype todo status

### DIFF
--- a/docs/prototype_todo.md
+++ b/docs/prototype_todo.md
@@ -5,54 +5,53 @@
 ## 目前進度概況
 
 ### Backend（Game Service）
-- 已有 FastAPI 應用程式骨架與健康檢查路由，並透過設定模組集中管理環境參數。【F:backend/app/main.py†L5-L18】【F:backend/app/api/routes/health.py†L1-L12】【F:backend/app/core/config.py†L1-L31】
-- 完成 `/api/rooms/{roomId}/objects` 物件提交端點，會計算 BBox 與 Anchor Ring、更新筆劃狀態、寫入審計紀錄並排入回合事件佇列。【F:backend/app/api/routes/rooms.py†L1-L33】【F:backend/app/services/objects.py†L1-L111】【F:backend/app/services/turns.py†L1-L52】
-- 目前資料層採用記憶體資料庫與 Redis wrapper，方便之後替換為 PostgreSQL 與實體 Redis。【F:backend/app/core/database.py†L1-L138】【F:backend/app/core/redis.py†L1-L66】
-- 具備物件提交流程的 pytest 覆蓋，驗證 turn queue 與審計紀錄是否寫入。【F:backend/app/tests/test_objects.py†L1-L77】
+- FastAPI lifespan 已掛載健康檢查、房間、筆劃路由，並在啟動時載入 TurnProcessor 以串接 AI 服務。【F:backend/app/main.py†L1-L46】【F:backend/app/api/routes/rooms.py†L1-L75】【F:backend/app/api/routes/strokes.py†L1-L41】
+- 房間／筆劃／物件服務串連記憶體資料庫與 Redis 事件佇列，建立 Turn 後會推送 `ws:events` 讓後續即時廣播使用；對應流程已有 pytest 驗證。【F:backend/app/services/objects.py†L1-L122】【F:backend/app/services/strokes.py†L12-L104】【F:backend/app/services/turn_processor.py†L1-L214】【F:backend/app/tests/test_strokes.py†L12-L56】【F:backend/app/tests/test_turn_processor.py†L14-L73】
+- 資料層仍採 in-memory Database 與 Redis wrapper，方便替換為真正的 PostgreSQL／Redis，但目前缺乏持久化能力。【F:backend/app/core/database.py†L1-L200】【F:backend/app/core/redis.py†L1-L87】
 
 ### Realtime Gateway
-- 已有基於 `ws` 套件的 WebSocket 伺服器，能按房間維持連線、接收 stroke/object/turn 主題訊息並轉發給其他客戶端。【F:realtime/src/index.ts†L1-L83】
-- Heartbeat/ping 機制與基本環境設定載入已就緒，但尚未串接後端或持久化訊息。【F:realtime/src/index.ts†L85-L98】【F:realtime/src/config.ts†L1-L10】
-- 完成連線強韌性優化：新增 payload 大小防護、速率限制、presence 廣播與超時終止閒置連線，並提供環境變數調校的設定檔匯入。【F:realtime/src/index.ts†L19-L218】【F:realtime/src/config.ts†L1-L28】
+- `ws` 伺服器具備房間管理、presence 廣播、速率限制與心跳維護，可轉發客戶端送出的 stroke/object/turn 訊息。【F:realtime/src/index.ts†L1-L353】【F:realtime/src/config.ts†L1-L28】
+- 目前尚未訂閱後端的 Redis 事件佇列，AI/Backend 產生的 `ws:events` 尚無法自動推送到連線用戶端。【F:backend/app/services/strokes.py†L12-L104】【F:backend/app/services/turn_processor.py†L151-L210】【F:realtime/src/index.ts†L177-L317】
 
 ### AI Agent
-- FastAPI 服務已建立 `/generate` 端點，並透過 `PatchGenerationPipeline` 回傳童話風格的佔位 patch payload，可作為整合時的假資料來源。【F:ai_agent/app/main.py†L1-L17】【F:ai_agent/app/pipelines/patch_generation.py†L1-L18】
+- FastAPI `/generate` 端點呼叫 `PatchGenerationPipeline` 回傳固定的童話風格 patch payload，作為 TurnProcessor 測試用的佔位回覆。【F:ai_agent/app/main.py†L1-L16】【F:ai_agent/app/pipelines/patch_generation.py†L1-L18】
 
 ### Frontend
-- 目前僅有 placeholder README，尚未建立 canvas、WebSocket 或 API 互動的實作。【F:frontend/README.md†L1-L4】
+- Vite + TypeScript 介面已組合工具列、物件面板與畫布容器，啟動時會建立房間、載入快照並連接 Realtime Gateway 與後端 API。【F:frontend/src/main.ts†L1-L169】
+- `InfiniteCanvas` 提供無限畫布、筆刷設定、平移縮放與 AI Patch 覆疊渲染；UI 元件支援筆刷調整、物件勾選與提交流程。【F:frontend/src/canvas/InfiniteCanvas.ts†L1-L200】【F:frontend/src/ui/Toolbar.ts†L1-L59】【F:frontend/src/ui/ObjectPanel.ts†L1-L105】
 
 ## Prototype 缺口摘要
-- 缺少房間建立/加入、筆劃同步與物件管理的 API／WS protocol 定義，前端無法實際連線。
-- 尚未實作客戶端畫布（繪圖、平移縮放）、stroke 序列化/反序列化與撤銷/重做。
-- AI patch 還未經過安全審核流程，也沒有 deliver 回 WebSocket 的回合事件。
-- 資料持久層仍為 in-memory；需評估在 Prototype 階段是否導入最小可用的 PostgreSQL/Redis 或維持記憶體並加上重設工具。
-- 自動化測試僅覆蓋物件提交流程，尚未覆蓋 WS、AI pipeline 或安全規則。
+- Backend 會把 stroke/object/turn 事件推入 Redis，但 Realtime Gateway 尚未消費 `ws:events`／`ws:object-events`，導致 AI patch 與物件狀態無法廣播給其他玩家。【F:backend/app/services/strokes.py†L12-L104】【F:backend/app/services/turn_processor.py†L151-L210】【F:realtime/src/index.ts†L177-L317】
+- TurnProcessor 目前僅回寫 `safety_status='passed'`，未串接 `content_safety` 檢核流程與封鎖邏輯，仍需補齊真正的兒童安全控管。【F:backend/app/services/turn_processor.py†L137-L210】
+- 資料層仍為記憶體／本機 Redis wrapper，Prototype 若要支援多人長時間遊戲仍需導入可持久化的 PostgreSQL／Redis 或備援機制。【F:backend/app/core/database.py†L1-L200】【F:backend/app/core/redis.py†L1-L87】
+- 目前測試聚焦在房間、筆劃、物件與 TurnProcessor 單元，尚缺 Realtime 橋接與端對端流程的整合測試。【F:backend/app/tests/test_rooms.py†L1-L87】【F:backend/app/tests/test_strokes.py†L12-L56】【F:backend/app/tests/test_turn_processor.py†L14-L73】
 
 ## 建議待辦與優先順序
 
-### Phase 1：最小可用迴路（Backend / Realtime） — ✅ 已完成
-1. **房間與使用者流程**：新增房間建立/加入 API，定義使用者身份（host/participant）及回傳目前 strokes/objects snapshot。
-2. **Stroke API 與佇列**：實作 `/api/rooms/{roomId}/strokes`（POST + 批次 GET）與對應的 WS broadcast 事件，確保畫布同步基礎可運作。
-3. **WS Protocol 套件化**：定義統一訊息格式（含 `topic`, `payload`, `timestamp`），補上 reconnect/心跳回應處理與錯誤回傳。
-4. **AI Turn webhook**：補上 turn queue 消費者（可先在 backend 內部使用 asyncio task），呼叫 AI Agent `/generate` 並寫入回合結果（含安全狀態 placeholder）。
+### Phase 1：最小可用迴路（Backend / Realtime） — ⏳ 部分完成
+- [x] **房間與使用者流程**：完成房間建立/加入 API，回傳當前 strokes/objects/turns 快照供前端初始化。【F:backend/app/api/routes/rooms.py†L1-L75】【F:backend/app/services/rooms.py†L1-L83】
+- [x] **Stroke API 與佇列**：建立 `/api/rooms/{roomId}/strokes` POST/GET，並將事件推入 `ws:events` 供即時同步。【F:backend/app/api/routes/strokes.py†L1-L41】【F:backend/app/services/strokes.py†L12-L104】
+- [x] **WS Protocol 套件化**：Realtime Gateway 具備統一 envelope、presence 與心跳控管，可轉發玩家送出的筆劃與系統訊息。【F:realtime/src/index.ts†L1-L353】
+- [x] **AI Turn webhook**：TurnProcessor 會消費 `turn:events`、呼叫 AI Agent 並將結果寫回審計／Redis 佇列。【F:backend/app/services/turn_processor.py†L1-L214】
+- [ ] **Backend ↔ Realtime 橋接**：新增背景程序訂閱 `ws:events`／`ws:object-events`，將 Backend/AI 事件推送至房間內所有連線（目前尚未實作）。【F:realtime/src/index.ts†L177-L317】
 
 ### Phase 2：前端 Canvas Prototype — ✅ 已完成
-1. **Canvas 繪圖工具列**：使用原生 TS 建立無限畫布（平移、縮放、筆寬/顏色、觸控手勢）。
-2. **WebSocket 同步**：串接 Realtime Gateway，實作 stroke buffering、節流與遠端筆劃渲染。
-3. **物件提交 UI**：提供合併筆劃為物件的流程（框選 or 選擇列表），並呼叫 backend object API。
-4. **AI Patch 顯示**：接收回合事件後在 anchor ring 內顯示 AI patch（先以假圖層 or 向量指令描繪），並顯示安全狀態。
+- [x] **Canvas 繪圖工具列**：`InfiniteCanvas` 支援平移、縮放、筆刷設定與繪圖事件；Toolbar 控制筆刷與視角重設。【F:frontend/src/canvas/InfiniteCanvas.ts†L12-L200】【F:frontend/src/ui/Toolbar.ts†L1-L59】
+- [x] **WebSocket 同步**：前端建立 RealtimeClient，連線後同步遠端筆劃並處理心跳／重連。【F:frontend/src/main.ts†L42-L138】【F:frontend/src/ws/RealtimeClient.ts†L1-L123】
+- [x] **物件提交 UI**：ObjectPanel 提供勾選筆劃與提交流程，呼叫後端物件 API。【F:frontend/src/ui/ObjectPanel.ts†L1-L105】【F:frontend/src/api/GameServiceClient.ts†L1-L91】
+- [x] **AI Patch 顯示**：收到 turn 事件後於畫布 Anchor Ring 呈現 AI patch 覆層與狀態提示。【F:frontend/src/main.ts†L57-L87】【F:frontend/src/canvas/InfiniteCanvas.ts†L77-L108】
 
 ### Phase 3：安全與審核基礎
-1. **文本過濾**：在 backend 對物件標籤/提示進行黑名單檢查，失敗時阻擋並透過 WS 回傳安全訊息。
-2. **影像佔位安全檢測**：為 AI patch 增加假實作的安全分數（可固定安全），為日後接入模型預留接口。
-3. **審計查詢 API**：新增 `/api/rooms/{roomId}/audit` 用於追蹤事件。
-4. **回放（基礎版）**：儲存 stroke/object/turn 事件順序，提供最簡回放 API（以 timestamp 過濾）。
+- [ ] **文本過濾**：在 backend 對物件標籤/提示進行黑名單檢查，失敗時阻擋並透過 WS 回傳安全訊息。
+- [ ] **影像佔位安全檢測**：為 AI patch 增加假實作的安全分數（可固定安全），為日後接入模型預留接口。
+- [ ] **審計查詢 API**：新增 `/api/rooms/{roomId}/audit` 用於追蹤事件。
+- [ ] **回放（基礎版）**：儲存 stroke/object/turn 事件順序，提供最簡回放 API（以 timestamp 過濾）。
 
 ### Phase 4：穩定性與部署準備
-1. **持久化策略**：視 Prototype 需求決定是否接上本地 PostgreSQL/Redis，或至少提供 dump/restore 工具以避免伺服器重啟即遺失資料。
-2. **測試覆蓋**：補上 WS integration 測試（pytest-asyncio）、AI pipeline 單元測試與前端單元測試（若建構工具允許）。
-3. **開發腳本**：撰寫 `make dev`/`docker-compose` 方便一次啟動 backend、realtime、ai_agent。
-4. **基本監控**：加入 Prometheus metrics 或最小 log 格式，以便 Prototype demo 時觀察系統狀態。
+- [ ] **持久化策略**：視 Prototype 需求決定是否接上本地 PostgreSQL/Redis，或至少提供 dump/restore 工具以避免伺服器重啟即遺失資料。【F:backend/app/core/database.py†L1-L200】【F:backend/app/core/redis.py†L1-L87】
+- [ ] **測試覆蓋**：補上 WS integration 測試（pytest-asyncio）、AI pipeline 單元測試與前端單元測試（若建構工具允許）。
+- [ ] **開發腳本**：撰寫 `make dev`/`docker-compose` 方便一次啟動 backend、realtime、ai_agent。
+- [ ] **基本監控**：加入 Prometheus metrics 或最小 log 格式，以便 Prototype demo 時觀察系統狀態。
 
 ---
-上述待辦可在 JIRA/Linear 等系統拆分為 Story/Task，優先完成 Phase 1 + Phase 2 即可達到「可試玩」原型目標，其餘 Phase 3-4 作為強化項目逐步補齊。
+上述待辦可在 JIRA/Linear 等系統拆分為 Story/Task；短期應優先補上 Backend ↔ Realtime 橋接與安全審核雛形，以串起「玩家 → AI」迴路，後續再逐步推進 Phase 3-4 的長期強化項目。


### PR DESCRIPTION
## Summary
- update `docs/prototype_todo.md` to reflect the current backend, realtime, AI, and frontend capabilities
- document remaining gaps such as the missing Redis → Realtime bridge, safety checks, persistence, and integration tests
- convert the phase roadmap into status checklists and call out the next priorities for completing the player→AI loop

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68e78d730e308328a8d571106b1429c5