### PR TITLE
Implement backend event bridge and content safety enforcement

### DIFF
--- a/backend/app/api/routes/events.py
+++ b/backend/app/api/routes/events.py
@@ -1,0 +1,48 @@
+"""API endpoints for streaming backend events to the realtime gateway."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Response, status
+
+from ...core.redis import RedisWrapper, get_redis_wrapper
+from ...services.strokes import OBJECT_EVENT_STREAM, WS_EVENT_STREAM
+
+
+router = APIRouter(tags=["events"])
+
+
+async def _select_stream(redis: RedisWrapper) -> dict[str, object] | None:
+    """Return the next event across object and general streams."""
+
+    async def _peek(key: str) -> tuple[str, dict[str, object]] | None:
+        events = await redis.list_events(key)
+        if not events:
+            return None
+        return key, events[0]
+
+    options: list[tuple[str, dict[str, object]]] = []
+    for key in (OBJECT_EVENT_STREAM, WS_EVENT_STREAM):
+        peeked = await _peek(key)
+        if peeked is not None:
+            options.append(peeked)
+
+    if not options:
+        return None
+
+    def _sort_key(item: tuple[str, dict[str, object]]) -> tuple[str, str]:
+        payload = item[1]
+        timestamp = str(payload.get("timestamp", ""))
+        return timestamp, item[0]
+
+    selected = min(options, key=_sort_key)
+    key = selected[0]
+    return await redis.pop_event(key)
+
+
+@router.get("/internal/events/next", response_model=None)
+async def get_next_event(redis: RedisWrapper = Depends(get_redis_wrapper)) -> Response | dict[str, object]:
+    """Return the next backend event for realtime delivery."""
+
+    event = await _select_stream(redis)
+    if event is None:
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
+    return event

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -34,6 +34,10 @@ class AppSettings(BaseSettings):
     turn_worker_poll_interval: float = Field(
         default=0.5, description="Polling interval for the turn worker"
     )
+    state_file: str | None = Field(
+        default="data/state.json",
+        description="Path to JSON file used for prototype persistence (set to empty to disable)",
+    )
 
 
 @lru_cache()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,6 +5,7 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 
+from .api.routes.events import router as events_router
 from .api.routes.health import router as health_router
 from .api.routes.rooms import router as rooms_router
 from .api.routes.strokes import router as strokes_router
@@ -39,6 +40,7 @@ def create_app() -> FastAPI:
     app.include_router(health_router, prefix=f"{settings.api_prefix}/health", tags=["health"])
     app.include_router(rooms_router, prefix=settings.api_prefix)
     app.include_router(strokes_router, prefix=settings.api_prefix)
+    app.include_router(events_router, prefix=settings.api_prefix)
 
     return app
 

--- a/backend/app/tests/test_database_persistence.py
+++ b/backend/app/tests/test_database_persistence.py
@@ -1,0 +1,98 @@
+import asyncio
+from uuid import uuid4
+
+from ..core.database import Database
+from ..models import (
+    AnchorRing,
+    AuditLog,
+    BBox,
+    CanvasObject,
+    ObjectStatus,
+    Point,
+    Room,
+    RoomMember,
+    RoomRole,
+    Stroke,
+    Turn,
+    TurnActor,
+    TurnStatus,
+)
+
+
+def test_database_persistence_roundtrip(tmp_path) -> None:
+    path = tmp_path / "state.json"
+    asyncio.run(_exercise_database(path))
+
+
+async def _exercise_database(path) -> None:
+    db = Database(storage_path=path)
+    room_id = uuid4()
+    user_id = uuid4()
+
+    room = Room(id=room_id, name="Persistent Room", turn_seq=2)
+    member = RoomMember(room_id=room_id, user_id=user_id, role=RoomRole.HOST)
+
+    inner_bbox = BBox(x=0.0, y=0.0, width=10.0, height=6.0)
+    outer_bbox = BBox(x=-2.0, y=-2.0, width=14.0, height=10.0)
+    anchor = AnchorRing(inner=inner_bbox, outer=outer_bbox)
+
+    canvas_object = CanvasObject(
+        room_id=room_id,
+        owner_id=user_id,
+        bbox=inner_bbox,
+        anchor_ring=anchor,
+        status=ObjectStatus.COMMITTED,
+        label="castle",
+    )
+
+    stroke = Stroke(
+        room_id=room_id,
+        author_id=user_id,
+        path=[Point(0.0, 0.0), Point(5.0, 5.0)],
+        color="#ffffff",
+        width=2.0,
+        object_id=canvas_object.id,
+    )
+
+    turn = Turn(
+        room_id=room_id,
+        sequence=1,
+        status=TurnStatus.AI_COMPLETED,
+        current_actor=TurnActor.PLAYER,
+        source_object_id=canvas_object.id,
+        ai_patch_uri="/cache/mock.png",
+        safety_status="passed",
+    )
+
+    audit_log = AuditLog(
+        room_id=room_id,
+        event_type="test.persisted",
+        payload={"ok": True},
+        user_id=user_id,
+        turn_id=turn.id,
+    )
+
+    async with db.transaction() as session:
+        session.save_room(room)
+        session.save_room_member(member)
+        session.save_object(canvas_object)
+        session.save_stroke(stroke)
+        session.save_turn(turn)
+        session.append_audit_log(audit_log)
+
+    assert path.exists()
+
+    db_reloaded = Database(storage_path=path)
+    async with db_reloaded.transaction() as session:
+        loaded_room = session.get_room(room_id)
+        assert loaded_room.name == "Persistent Room"
+        strokes = session.list_strokes(room_id)
+        assert len(strokes) == 1
+        assert strokes[0].object_id == canvas_object.id
+        loaded_object = session.get_object(canvas_object.id)
+        assert loaded_object.anchor_ring.outer.width == outer_bbox.width
+        loaded_turn = session.get_turn(turn.id)
+        assert loaded_turn.ai_patch_uri == "/cache/mock.png"
+        assert loaded_turn.safety_status == "passed"
+        logs = session.list_audit_logs(room_id)
+        assert logs and logs[0].payload["ok"] is True

--- a/backend/app/tests/test_events_api.py
+++ b/backend/app/tests/test_events_api.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from ..api.routes.events import get_next_event
+from ..core.redis import RedisWrapper
+from ..services.strokes import OBJECT_EVENT_STREAM, WS_EVENT_STREAM
+
+
+def test_get_next_event_returns_204_when_empty() -> None:
+    redis = RedisWrapper()
+    response = asyncio.run(get_next_event(redis=redis))
+    assert hasattr(response, "status_code")
+    assert response.status_code == 204
+
+
+def test_get_next_event_prioritises_oldest() -> None:
+    redis = RedisWrapper()
+    room_id = str(uuid4())
+
+    newer_event = {
+        "topic": "turn",
+        "roomId": room_id,
+        "timestamp": datetime(2024, 1, 5, tzinfo=timezone.utc).isoformat(),
+        "payload": {"turnId": str(uuid4())},
+    }
+    older_event = {
+        "topic": "object",
+        "roomId": room_id,
+        "timestamp": datetime(2024, 1, 1, tzinfo=timezone.utc).isoformat(),
+        "payload": {"id": str(uuid4())},
+    }
+
+    asyncio.run(redis.enqueue_json(WS_EVENT_STREAM, newer_event))
+    asyncio.run(redis.enqueue_json(OBJECT_EVENT_STREAM, older_event))
+
+    result = asyncio.run(get_next_event(redis=redis))
+    assert isinstance(result, dict)
+    assert result["timestamp"] == older_event["timestamp"]
+    assert result["topic"] == "object"

--- a/backend/app/tests/test_turn_processor.py
+++ b/backend/app/tests/test_turn_processor.py
@@ -39,6 +39,11 @@ async def _run_turn_processor() -> None:
     async with db.transaction() as session:
         response = await commit_object(room_id=room_id, payload=payload, session=session, redis=redis)
 
+    object_events = await redis.list_events("ws:object-events")
+    assert len(object_events) == 1
+    assert object_events[0]["topic"] == "object"
+    assert object_events[0]["payload"]["roomId"] == str(room_id)
+
     queued_payload = await redis.pop_event("turn:events")
     assert queued_payload is not None
 
@@ -69,6 +74,81 @@ async def _run_turn_processor() -> None:
     ws_events = await redis.list_events("ws:events")
     assert len(ws_events) == 1
     assert ws_events[0]["topic"] == "turn"
-    assert ws_events[0]["payload"]["turnId"] == str(response.turn.id)
+    payload = ws_events[0]["payload"]
+    assert payload["turnId"] == str(response.turn.id)
+    assert payload["safetyStatus"] == "passed"
+    assert payload["safety"]["passed"] is True
+
+    await client.aclose()
+
+
+def test_turn_processor_blocks_on_safety() -> None:
+    asyncio.run(_run_turn_processor_blocked())
+
+
+async def _run_turn_processor_blocked() -> None:
+    db = Database()
+    redis = RedisWrapper()
+
+    room_id = uuid4()
+    user_id = uuid4()
+    stroke_id = uuid4()
+
+    room = Room(id=room_id, name="Adventure Room")
+    stroke = Stroke(
+        id=stroke_id,
+        room_id=room_id,
+        author_id=user_id,
+        path=[Point(0.0, 0.0), Point(5.0, 5.0)],
+        color="#000000",
+        width=3.0,
+    )
+    db.insert_room(room)
+    db.insert_stroke(stroke)
+
+    payload = ObjectCreatePayload(owner_id=user_id, stroke_ids=[stroke_id])
+    async with db.transaction() as session:
+        response = await commit_object(room_id=room_id, payload=payload, session=session, redis=redis)
+
+    object_events = await redis.list_events("ws:object-events")
+    assert len(object_events) == 1
+    assert object_events[0]["topic"] == "object"
+    assert object_events[0]["payload"]["roomId"] == str(room_id)
+
+    queued_payload = await redis.pop_event("turn:events")
+    assert queued_payload is not None
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/generate"
+        return httpx.Response(
+            200,
+            json={"patch": {"instructions": "add spooky blood everywhere"}},
+        )
+
+    transport = httpx.MockTransport(handler)
+    client = httpx.AsyncClient(transport=transport, base_url="http://agent")
+
+    processor = TurnProcessor(
+        redis,
+        agent_url="http://agent",
+        poll_interval=0.01,
+        database=db,
+        client=client,
+    )
+
+    event = TurnEvent.from_payload(queued_payload)
+    await processor._process_event(event, client)
+
+    async with db.transaction() as session:
+        turn = session.get_turn(response.turn.id)
+        assert turn.status == TurnStatus.BLOCKED
+        assert turn.safety_status == "blocked"
+
+    ws_events = await redis.list_events("ws:events")
+    assert len(ws_events) == 1
+    payload_event = ws_events[0]["payload"]
+    assert payload_event["safetyStatus"] == "blocked"
+    assert payload_event["safety"]["passed"] is False
+    assert "blood" in payload_event["safety"]["reasons"]
 
     await client.aclose()

--- a/realtime/src/config.ts
+++ b/realtime/src/config.ts
@@ -10,6 +10,8 @@ export interface GatewayConfig {
   heartbeatToleranceMs: number;
   maxPayloadBytes: number;
   rateLimit: RateLimitConfig;
+  gameServiceUrl: string;
+  eventPollIntervalMs: number;
 }
 
 const numberFromEnv = (key: string, fallback: number): number => {
@@ -31,4 +33,6 @@ export const loadConfig = (): GatewayConfig => ({
     burst: numberFromEnv('GATEWAY_RATE_LIMIT_BURST', 40),
     refillIntervalMs: numberFromEnv('GATEWAY_RATE_LIMIT_REFILL_MS', 1000),
   },
+  gameServiceUrl: process.env.GAME_SERVICE_URL ?? 'http://localhost:8000',
+  eventPollIntervalMs: numberFromEnv('GATEWAY_EVENT_POLL_MS', 250),
 });

--- a/realtime/tsconfig.json
+++ b/realtime/tsconfig.json
@@ -8,7 +8,8 @@
     "esModuleInterop": true,
     "strict": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "lib": ["ES2022", "DOM"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary
- add a persistence-aware database layer and expose an internal `/internal/events/next` endpoint so realtime can drain backend queues
- integrate the content safety moderation pipeline into the turn processor and broadcast safety metadata with AI turns
- switch the realtime gateway to HTTP poll the new backend endpoint, and add regression tests for persistence, event streaming, and safety handling

## Testing
- pytest -q
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ed261253248328b6866c7b9ccaa787