### PR TITLE
Implement persistent storage, auth, and reliable realtime streams

### DIFF
--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,0 +1,35 @@
+[alembic]
+script_location = alembic
+sqlalchemy.url = %(database_url)s
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stdout,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)s [%(name)s] %(message)s

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import os
+import sys
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+# Ensure the app package is importable when Alembic runs standalone.
+BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+if BASE_DIR not in sys.path:
+    sys.path.append(BASE_DIR)
+
+from app.core.config import get_settings
+from app.core.db.models import Base
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    settings = get_settings()
+    url = settings.database_url
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        compare_type=True,
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    settings = get_settings()
+    config_section = config.get_section(config.config_ini_section) or {}
+    connectable = engine_from_config(
+        config_section,
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+        url=settings.database_url,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata, compare_type=True)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+def run_migrations() -> None:
+    if context.is_offline_mode():
+        run_migrations_offline()
+    else:
+        run_migrations_online()
+
+
+run_migrations()

--- a/backend/alembic/versions/0001_initial.py
+++ b/backend/alembic/versions/0001_initial.py
@@ -1,0 +1,90 @@
+"""Initial schema"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0001_initial"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "rooms",
+        sa.Column("id", sa.String(length=36), primary_key=True),
+        sa.Column("name", sa.String(length=200), nullable=False),
+        sa.Column("turn_seq", sa.Integer(), nullable=False, default=0),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+    )
+
+    op.create_table(
+        "room_members",
+        sa.Column("room_id", sa.String(length=36), sa.ForeignKey("rooms.id", ondelete="CASCADE"), primary_key=True),
+        sa.Column("user_id", sa.String(length=36), primary_key=True),
+        sa.Column("role", sa.String(length=50), nullable=False),
+        sa.Column("joined_at", sa.DateTime(timezone=True), nullable=False),
+    )
+
+    op.create_table(
+        "objects",
+        sa.Column("id", sa.String(length=36), primary_key=True),
+        sa.Column("room_id", sa.String(length=36), sa.ForeignKey("rooms.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("owner_id", sa.String(length=36), nullable=False),
+        sa.Column("bbox", sa.JSON(), nullable=False),
+        sa.Column("anchor_ring", sa.JSON(), nullable=False),
+        sa.Column("status", sa.String(length=20), nullable=False),
+        sa.Column("label", sa.String(length=120)),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+    )
+
+    op.create_table(
+        "strokes",
+        sa.Column("id", sa.String(length=36), primary_key=True),
+        sa.Column("room_id", sa.String(length=36), sa.ForeignKey("rooms.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("author_id", sa.String(length=36), nullable=False),
+        sa.Column("color", sa.String(length=50), nullable=False),
+        sa.Column("width", sa.Float(), nullable=False),
+        sa.Column("ts", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("path", sa.JSON(), nullable=False),
+        sa.Column("object_id", sa.String(length=36), sa.ForeignKey("objects.id", ondelete="SET NULL")),
+    )
+
+    op.create_table(
+        "turns",
+        sa.Column("id", sa.String(length=36), primary_key=True),
+        sa.Column("room_id", sa.String(length=36), sa.ForeignKey("rooms.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("sequence", sa.Integer(), nullable=False),
+        sa.Column("status", sa.String(length=30), nullable=False),
+        sa.Column("current_actor", sa.String(length=30), nullable=False),
+        sa.Column("source_object_id", sa.String(length=36), sa.ForeignKey("objects.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("ai_patch_uri", sa.String(length=500)),
+        sa.Column("safety_status", sa.String(length=50)),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+    )
+
+    op.create_table(
+        "audit_logs",
+        sa.Column("id", sa.String(length=36), primary_key=True),
+        sa.Column("room_id", sa.String(length=36), sa.ForeignKey("rooms.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("user_id", sa.String(length=36)),
+        sa.Column("turn_id", sa.String(length=36), sa.ForeignKey("turns.id", ondelete="SET NULL")),
+        sa.Column("event_type", sa.String(length=120), nullable=False),
+        sa.Column("payload", sa.JSON(), nullable=False),
+        sa.Column("ts", sa.DateTime(timezone=True), nullable=False),
+    )
+
+    op.create_index("ix_turns_room_sequence", "turns", ["room_id", "sequence"], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_turns_room_sequence", table_name="turns")
+    op.drop_table("audit_logs")
+    op.drop_table("turns")
+    op.drop_table("strokes")
+    op.drop_table("objects")
+    op.drop_table("room_members")
+    op.drop_table("rooms")

--- a/backend/app/api/routes/events.py
+++ b/backend/app/api/routes/events.py
@@ -1,48 +1,28 @@
 """API endpoints for streaming backend events to the realtime gateway."""
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, Response, status
+from fastapi import APIRouter, Depends, Query, Response, status
 
 from ...core.redis import RedisWrapper, get_redis_wrapper
-from ...services.strokes import OBJECT_EVENT_STREAM, WS_EVENT_STREAM
+from ...core.security import AuthenticatedSubject, UserRole, require_roles
 
 
 router = APIRouter(tags=["events"])
 
 
-async def _select_stream(redis: RedisWrapper) -> dict[str, object] | None:
-    """Return the next event across object and general streams."""
-
-    async def _peek(key: str) -> tuple[str, dict[str, object]] | None:
-        events = await redis.list_events(key)
-        if not events:
-            return None
-        return key, events[0]
-
-    options: list[tuple[str, dict[str, object]]] = []
-    for key in (OBJECT_EVENT_STREAM, WS_EVENT_STREAM):
-        peeked = await _peek(key)
-        if peeked is not None:
-            options.append(peeked)
-
-    if not options:
-        return None
-
-    def _sort_key(item: tuple[str, dict[str, object]]) -> tuple[str, str]:
-        payload = item[1]
-        timestamp = str(payload.get("timestamp", ""))
-        return timestamp, item[0]
-
-    selected = min(options, key=_sort_key)
-    key = selected[0]
-    return await redis.pop_event(key)
-
-
 @router.get("/internal/events/next", response_model=None)
-async def get_next_event(redis: RedisWrapper = Depends(get_redis_wrapper)) -> Response | dict[str, object]:
-    """Return the next backend event for realtime delivery."""
+async def get_next_event(
+    cursor: str | None = Query(default=None, description="Replay cursor"),
+    limit: int = Query(default=1, ge=1, le=100, description="Number of events to fetch"),
+    redis: RedisWrapper = Depends(get_redis_wrapper),
+    _: AuthenticatedSubject = Depends(
+        require_roles(UserRole.MODERATOR, UserRole.PARENT)
+    ),
+) -> Response | dict[str, object]:
+    """Return realtime events along with a cursor for replay."""
 
-    event = await _select_stream(redis)
-    if event is None:
+    events = await redis.list_timeline_events(cursor=cursor, limit=limit)
+    if not events:
         return Response(status_code=status.HTTP_204_NO_CONTENT)
-    return event
+    next_cursor = events[-1]["cursor"]
+    return {"cursor": next_cursor, "events": events}

--- a/backend/app/api/routes/rooms.py
+++ b/backend/app/api/routes/rooms.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, status
 
 from ...core.database import DatabaseSession, get_db_session
 from ...core.redis import RedisWrapper, get_redis
+from ...core.security import AuthenticatedSubject, UserRole, require_roles
 from ...schemas.objects import ObjectCreatePayload, ObjectCreateResponse
 from ...schemas.rooms import (
     RoomCreatePayload,
@@ -34,7 +35,14 @@ def _snapshot_response(snapshot: RoomSnapshot) -> RoomSnapshotResponse:
 async def create_room_endpoint(
     payload: RoomCreatePayload,
     session: DatabaseSession = Depends(get_db_session),
+    subject: AuthenticatedSubject = Depends(
+        require_roles(UserRole.PLAYER, UserRole.MODERATOR, UserRole.PARENT)
+    ),
 ) -> RoomSnapshotResponse:
+    if subject.role == UserRole.PLAYER and payload.host_id != subject.user_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="cannot_create_for_other_user"
+        )
     snapshot = await create_room(session, name=payload.name, host_id=payload.host_id)
     return _snapshot_response(snapshot)
 
@@ -44,7 +52,14 @@ async def join_room_endpoint(
     room_id: UUID,
     payload: RoomJoinPayload,
     session: DatabaseSession = Depends(get_db_session),
+    subject: AuthenticatedSubject = Depends(
+        require_roles(UserRole.PLAYER, UserRole.MODERATOR, UserRole.PARENT)
+    ),
 ) -> RoomSnapshotResponse:
+    if subject.role == UserRole.PLAYER and payload.user_id != subject.user_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="cannot_join_for_other_user"
+        )
     snapshot = await join_room(session, room_id=room_id, user_id=payload.user_id)
     return _snapshot_response(snapshot)
 
@@ -55,7 +70,14 @@ async def commit_object(
     payload: ObjectCreatePayload,
     session: DatabaseSession = Depends(get_db_session),
     redis: RedisWrapper = Depends(get_redis),
+    subject: AuthenticatedSubject = Depends(
+        require_roles(UserRole.PLAYER, UserRole.MODERATOR, UserRole.PARENT)
+    ),
 ) -> ObjectCreateResponse:
+    if subject.role == UserRole.PLAYER and payload.owner_id != subject.user_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="cannot_commit_for_other_user"
+        )
     try:
         canvas_object, turn, room = await create_object(
             session,

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -25,6 +25,15 @@ class AppSettings(BaseSettings):
     redis_url: str = Field(
         default="redis://localhost:6379/0", description="Redis connection URI"
     )
+    auth_secret_key: str = Field(
+        default="dev-secret", description="HMAC secret for signing access tokens"
+    )
+    auth_algorithm: str = Field(
+        default="HS256", description="JWT signing algorithm"
+    )
+    access_token_expire_minutes: int = Field(
+        default=60, description="Access token lifetime in minutes"
+    )
     ai_agent_url: str = Field(
         default="http://localhost:8100", description="Base URL for the AI agent"
     )

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -1,15 +1,15 @@
-"""Simplified database layer with optional disk persistence."""
+"""Database layer supporting both SQLAlchemy and in-memory fallbacks."""
 from __future__ import annotations
 
 import asyncio
 import json
 from collections import defaultdict
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Iterable
 from contextlib import asynccontextmanager
 from dataclasses import replace
 from datetime import datetime
 from pathlib import Path
-from typing import Iterable
+from typing import Any
 from uuid import UUID
 
 from ..models import (
@@ -29,425 +29,586 @@ from ..models import (
 )
 from .config import get_settings
 
+try:  # pragma: no cover - optional dependency
+    from sqlalchemy import Select, select, update
+    from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker, create_async_engine
+    from sqlalchemy.pool import StaticPool
 
-class Database:
-    """A lightweight transactional store that mimics PostgreSQL semantics."""
+    from .db.models import AuditLogORM, Base, ObjectORM, RoomMemberORM, RoomORM, StrokeORM, TurnORM
 
-    def __init__(self, *, storage_path: str | Path | None = None) -> None:
-        self._rooms: dict[UUID, Room] = {}
-        self._strokes: dict[UUID, Stroke] = {}
-        self._objects: dict[UUID, CanvasObject] = {}
-        self._turns: dict[UUID, Turn] = {}
-        self._audit_logs: dict[UUID, AuditLog] = {}
-        self._members: dict[tuple[UUID, UUID], RoomMember] = {}
-        self._room_member_index: defaultdict[UUID, list[UUID]] = defaultdict(list)
-        self._room_turn_index: defaultdict[UUID, list[UUID]] = defaultdict(list)
-        self._lock = asyncio.Lock()
-        self._storage_path = Path(storage_path).expanduser() if storage_path else None
-        if self._storage_path:
-            self._storage_path.parent.mkdir(parents=True, exist_ok=True)
-            self._load_from_disk()
-
-    @asynccontextmanager
-    async def transaction(self) -> AsyncIterator["DatabaseSession"]:
-        async with self._lock:
-            session = DatabaseSession(self)
-            yield session
-            if session.commit():
-                self._persist()
-
-    # Convenience helpers used by tests to bootstrap data -----------------
-
-    def insert_room(self, room: Room) -> None:
-        self._rooms[room.id] = room
-
-    def insert_stroke(self, stroke: Stroke) -> None:
-        self._strokes[stroke.id] = stroke
-
-    # Internal helpers -----------------------------------------------------
-
-    def _save_object(self, obj: CanvasObject) -> None:
-        self._objects[obj.id] = obj
-
-    def _save_turn(self, turn: Turn) -> None:
-        self._turns[turn.id] = turn
-        self._room_turn_index[turn.room_id].append(turn.id)
-
-    def _save_audit_log(self, log: AuditLog) -> None:
-        self._audit_logs[log.id] = log
-
-    def _save_room(self, room: Room) -> None:
-        self._rooms[room.id] = room
-
-    def _save_stroke(self, stroke: Stroke) -> None:
-        self._strokes[stroke.id] = stroke
-
-    def _save_member(self, member: RoomMember) -> None:
-        key = (member.room_id, member.user_id)
-        if key not in self._members:
-            self._room_member_index[member.room_id].append(member.user_id)
-        self._members[key] = member
-        self._room_member_index[member.room_id] = list(dict.fromkeys(self._room_member_index[member.room_id]))
-
-    # Persistence helpers -------------------------------------------------
-
-    def _persist(self) -> None:
-        if self._storage_path is None:
-            return
-        payload = {
-            "rooms": [self._serialise_room(room) for room in self._rooms.values()],
-            "strokes": [self._serialise_stroke(stroke) for stroke in self._strokes.values()],
-            "objects": [self._serialise_object(obj) for obj in self._objects.values()],
-            "turns": [self._serialise_turn(turn) for turn in self._turns.values()],
-            "audit_logs": [self._serialise_audit(log) for log in self._audit_logs.values()],
-            "members": [self._serialise_member(member) for member in self._members.values()],
-        }
-        tmp_path = self._storage_path.with_suffix(".tmp")
-        with tmp_path.open("w", encoding="utf-8") as fh:
-            json.dump(payload, fh, indent=2)
-        tmp_path.replace(self._storage_path)
-
-    def _load_from_disk(self) -> None:
-        if self._storage_path is None or not self._storage_path.exists():
-            return
-        with self._storage_path.open("r", encoding="utf-8") as fh:
-            data = json.load(fh)
-
-        self._rooms = {UUID(item["id"]): self._deserialise_room(item) for item in data.get("rooms", [])}
-        self._strokes = {
-            UUID(item["id"]): self._deserialise_stroke(item) for item in data.get("strokes", [])
-        }
-        self._objects = {
-            UUID(item["id"]): self._deserialise_object(item) for item in data.get("objects", [])
-        }
-        self._turns = {UUID(item["id"]): self._deserialise_turn(item) for item in data.get("turns", [])}
-        self._audit_logs = {
-            UUID(item["id"]): self._deserialise_audit(item) for item in data.get("audit_logs", [])
-        }
-        self._members = {
-            (UUID(item["room_id"]), UUID(item["user_id"])): self._deserialise_member(item)
-            for item in data.get("members", [])
-        }
-
-        self._room_member_index.clear()
-        for member in self._members.values():
-            self._room_member_index[member.room_id].append(member.user_id)
-
-        self._room_turn_index.clear()
-        for turn in self._turns.values():
-            self._room_turn_index[turn.room_id].append(turn.id)
-
-    @staticmethod
-    def _serialise_room(room: Room) -> dict[str, object]:
-        return {
-            "id": str(room.id),
-            "name": room.name,
-            "turn_seq": room.turn_seq,
-            "created_at": room.created_at.isoformat(),
-        }
-
-    @staticmethod
-    def _deserialise_room(data: dict[str, object]) -> Room:
-        return Room(
-            id=UUID(str(data["id"])),
-            name=str(data["name"]),
-            turn_seq=int(data.get("turn_seq", 0)),
-            created_at=datetime.fromisoformat(str(data["created_at"])),
-        )
-
-    @staticmethod
-    def _serialise_point(point: Point) -> dict[str, float]:
-        return {"x": point.x, "y": point.y}
-
-    @staticmethod
-    def _deserialise_point(data: dict[str, object]) -> Point:
-        return Point(float(data["x"]), float(data["y"]))
-
-    @classmethod
-    def _serialise_stroke(cls, stroke: Stroke) -> dict[str, object]:
-        return {
-            "id": str(stroke.id),
-            "room_id": str(stroke.room_id),
-            "author_id": str(stroke.author_id),
-            "color": stroke.color,
-            "width": stroke.width,
-            "ts": stroke.ts.isoformat(),
-            "path": [cls._serialise_point(point) for point in stroke.path],
-            "object_id": str(stroke.object_id) if stroke.object_id else None,
-        }
-
-    @classmethod
-    def _deserialise_stroke(cls, data: dict[str, object]) -> Stroke:
-        path = [cls._deserialise_point(point) for point in data.get("path", [])]  # type: ignore[arg-type]
-        object_id = data.get("object_id")
-        return Stroke(
-            id=UUID(str(data["id"])),
-            room_id=UUID(str(data["room_id"])),
-            author_id=UUID(str(data["author_id"])),
-            path=path,
-            color=str(data["color"]),
-            width=float(data["width"]),
-            ts=datetime.fromisoformat(str(data["ts"])),
-            object_id=UUID(object_id) if object_id else None,
-        )
-
-    @staticmethod
-    def _serialise_bbox(bbox: BBox) -> dict[str, float]:
-        return bbox.to_dict()
-
-    @staticmethod
-    def _deserialise_bbox(data: dict[str, object]) -> BBox:
-        return BBox(
-            x=float(data["x"]),
-            y=float(data["y"]),
-            width=float(data["width"]),
-            height=float(data["height"]),
-        )
-
-    @classmethod
-    def _serialise_object(cls, obj: CanvasObject) -> dict[str, object]:
-        return {
-            "id": str(obj.id),
-            "room_id": str(obj.room_id),
-            "owner_id": str(obj.owner_id),
-            "label": obj.label,
-            "status": obj.status.value,
-            "bbox": cls._serialise_bbox(obj.bbox),
-            "anchor_ring": {
-                "inner": cls._serialise_bbox(obj.anchor_ring.inner),
-                "outer": cls._serialise_bbox(obj.anchor_ring.outer),
-            },
-            "created_at": obj.created_at.isoformat(),
-        }
-
-    @classmethod
-    def _deserialise_object(cls, data: dict[str, object]) -> CanvasObject:
-        anchor = data.get("anchor_ring", {})
-        inner = cls._deserialise_bbox(anchor.get("inner", {}))  # type: ignore[arg-type]
-        outer = cls._deserialise_bbox(anchor.get("outer", {}))  # type: ignore[arg-type]
-        return CanvasObject(
-            id=UUID(str(data["id"])),
-            room_id=UUID(str(data["room_id"])),
-            owner_id=UUID(str(data["owner_id"])),
-            label=data.get("label") if data.get("label") is not None else None,
-            status=ObjectStatus(str(data["status"])),
-            bbox=cls._deserialise_bbox(data["bbox"]),  # type: ignore[arg-type]
-            anchor_ring=AnchorRing(inner=inner, outer=outer),
-            created_at=datetime.fromisoformat(str(data["created_at"])),
-        )
-
-    @staticmethod
-    def _serialise_turn(turn: Turn) -> dict[str, object]:
-        return {
-            "id": str(turn.id),
-            "room_id": str(turn.room_id),
-            "sequence": turn.sequence,
-            "status": turn.status.value,
-            "current_actor": turn.current_actor.value,
-            "source_object_id": str(turn.source_object_id),
-            "ai_patch_uri": turn.ai_patch_uri,
-            "safety_status": turn.safety_status,
-            "created_at": turn.created_at.isoformat(),
-            "updated_at": turn.updated_at.isoformat(),
-        }
-
-    @staticmethod
-    def _deserialise_turn(data: dict[str, object]) -> Turn:
-        return Turn(
-            id=UUID(str(data["id"])),
-            room_id=UUID(str(data["room_id"])),
-            sequence=int(data["sequence"]),
-            status=TurnStatus(str(data["status"])),
-            current_actor=TurnActor(str(data["current_actor"])),
-            source_object_id=UUID(str(data["source_object_id"])),
-            ai_patch_uri=data.get("ai_patch_uri") if data.get("ai_patch_uri") is not None else None,
-            safety_status=data.get("safety_status"),
-            created_at=datetime.fromisoformat(str(data["created_at"])),
-            updated_at=datetime.fromisoformat(str(data["updated_at"])),
-        )
-
-    @staticmethod
-    def _serialise_audit(log: AuditLog) -> dict[str, object]:
-        return {
-            "id": str(log.id),
-            "room_id": str(log.room_id),
-            "event_type": log.event_type,
-            "payload": log.payload,
-            "user_id": str(log.user_id) if log.user_id else None,
-            "turn_id": str(log.turn_id) if log.turn_id else None,
-            "ts": log.ts.isoformat(),
-        }
-
-    @staticmethod
-    def _deserialise_audit(data: dict[str, object]) -> AuditLog:
-        turn_id = data.get("turn_id")
-        user_id = data.get("user_id")
-        return AuditLog(
-            id=UUID(str(data["id"])),
-            room_id=UUID(str(data["room_id"])),
-            event_type=str(data["event_type"]),
-            payload=data.get("payload", {}),
-            user_id=UUID(user_id) if user_id else None,
-            turn_id=UUID(turn_id) if turn_id else None,
-            ts=datetime.fromisoformat(str(data["ts"])),
-        )
-
-    @staticmethod
-    def _serialise_member(member: RoomMember) -> dict[str, object]:
-        return {
-            "room_id": str(member.room_id),
-            "user_id": str(member.user_id),
-            "role": member.role.value,
-            "joined_at": member.joined_at.isoformat(),
-        }
-
-    @staticmethod
-    def _deserialise_member(data: dict[str, object]) -> RoomMember:
-        return RoomMember(
-            room_id=UUID(str(data["room_id"])),
-            user_id=UUID(str(data["user_id"])),
-            role=RoomRole(str(data["role"])),
-            joined_at=datetime.fromisoformat(str(data["joined_at"])),
-        )
+    SQLALCHEMY_AVAILABLE = True
+except ModuleNotFoundError:  # pragma: no cover - when dependencies missing
+    SQLALCHEMY_AVAILABLE = False
 
 
-class DatabaseSession:
-    """Single transaction facade used by services."""
+if SQLALCHEMY_AVAILABLE:  # pragma: no cover - exercised via integration tests
 
-    def __init__(self, db: Database) -> None:
-        self._db = db
-        self._pending_audit_logs: list[AuditLog] = []
-        self._pending_turns: list[Turn] = []
-        self._pending_objects: list[CanvasObject] = []
-        self._pending_rooms: list[Room] = []
-        self._pending_strokes: list[Stroke] = []
-        self._pending_members: list[RoomMember] = []
-        self._updated_strokes: list[Stroke] = []
+    class Database:
+        """Async database facade that exposes high-level helpers used by services."""
 
-    # Lookup helpers -------------------------------------------------------
+        def __init__(self, *, database_url: str | None = None, echo: bool = False) -> None:
+            settings = get_settings()
+            self._database_url = database_url or settings.database_url
+            engine_kwargs: dict[str, Any] = {"echo": echo, "future": True}
+            if self._database_url.startswith("sqlite+aiosqlite"):
+                engine_kwargs["connect_args"] = {"check_same_thread": False}
+                engine_kwargs["poolclass"] = StaticPool
+            self._engine: AsyncEngine = create_async_engine(self._database_url, **engine_kwargs)
+            self._session_factory = async_sessionmaker(self._engine, expire_on_commit=False)
 
-    def get_room(self, room_id: UUID) -> Room:
-        room = self._db._rooms.get(room_id)
-        if room is None:
-            raise LookupError("room_not_found")
-        return room
+        async def create_all(self) -> None:
+            async with self._engine.begin() as conn:
+                await conn.run_sync(Base.metadata.create_all)
 
-    def get_strokes(self, room_id: UUID, stroke_ids: Iterable[UUID]) -> list[Stroke]:
-        found: list[Stroke] = []
-        for stroke_id in stroke_ids:
-            stroke = self._db._strokes.get(stroke_id)
-            if stroke is None or stroke.room_id != room_id:
-                raise LookupError("stroke_not_found")
-            found.append(stroke)
-        return found
+        async def dispose(self) -> None:
+            await self._engine.dispose()
 
-    def get_turns_for_room(self, room_id: UUID) -> list[Turn]:
-        return [self._db._turns[turn_id] for turn_id in self._db._room_turn_index.get(room_id, [])]
+        @asynccontextmanager
+        async def transaction(self) -> AsyncIterator["DatabaseSession"]:
+            async with self._session_factory() as session:
+                async with session.begin():
+                    yield DatabaseSession(session)
 
-    def get_object(self, object_id: UUID) -> CanvasObject:
-        obj = self._db._objects.get(object_id)
-        if obj is None:
-            raise LookupError("object_not_found")
-        return obj
 
-    def list_objects(self, room_id: UUID) -> list[CanvasObject]:
-        return [obj for obj in self._db._objects.values() if obj.room_id == room_id]
+    class DatabaseSession:
+        """Wrap an AsyncSession with domain-specific helpers."""
 
-    def get_turn(self, turn_id: UUID) -> Turn:
-        turn = self._db._turns.get(turn_id)
-        if turn is None:
-            raise LookupError("turn_not_found")
-        return turn
+        def __init__(self, session: AsyncSession) -> None:
+            self._session = session
 
-    def get_stroke(self, stroke_id: UUID) -> Stroke:
-        stroke = self._db._strokes.get(stroke_id)
-        if stroke is None:
-            raise LookupError("stroke_not_found")
-        return stroke
+        async def save_room(self, room: Room) -> None:
+            self._session.add(RoomORM.from_domain(room))
 
-    def list_strokes(self, room_id: UUID) -> list[Stroke]:
-        strokes = [stroke for stroke in self._db._strokes.values() if stroke.room_id == room_id]
-        return sorted(strokes, key=lambda stroke: stroke.ts)
-
-    def get_room_member(self, room_id: UUID, user_id: UUID) -> RoomMember:
-        member = self._db._members.get((room_id, user_id))
-        if member is None:
-            raise LookupError("member_not_found")
-        return member
-
-    def list_room_members(self, room_id: UUID) -> list[RoomMember]:
-        members = [self._db._members[(room_id, user_id)] for user_id in self._db._room_member_index.get(room_id, [])]
-        for member in self._pending_members:
-            if member.room_id == room_id and member not in members:
-                members.append(member)
-        return members
-
-    def list_audit_logs(self, room_id: UUID | None = None) -> list[AuditLog]:
-        logs = list(self._db._audit_logs.values())
-        if room_id is not None:
-            logs = [log for log in logs if log.room_id == room_id]
-        return logs
-
-    # Mutation helpers -----------------------------------------------------
-
-    def save_object(self, obj: CanvasObject) -> None:
-        self._pending_objects.append(obj)
-
-    def save_room(self, room: Room) -> None:
-        self._pending_rooms.append(room)
-
-    def save_stroke(self, stroke: Stroke) -> None:
-        self._pending_strokes.append(stroke)
-
-    def save_room_member(self, member: RoomMember) -> None:
-        self._pending_members.append(member)
-
-    def update_stroke(self, stroke: Stroke, *, object_id: UUID) -> None:
-        updated = replace(stroke, object_id=object_id)
-        self._updated_strokes.append(updated)
-
-    def save_turn(self, turn: Turn) -> None:
-        self._pending_turns.append(turn)
-
-    def append_audit_log(self, log: AuditLog) -> None:
-        self._pending_audit_logs.append(log)
-
-    def commit(self) -> bool:
-        changed = any(
-            collection
-            for collection in (
-                self._pending_rooms,
-                self._pending_strokes,
-                self._pending_members,
-                self._pending_objects,
-                self._updated_strokes,
-                self._pending_turns,
-                self._pending_audit_logs,
+        async def update_room(self, room: Room) -> None:
+            await self._session.execute(
+                update(RoomORM)
+                .where(RoomORM.id == room.id)
+                .values(name=room.name, turn_seq=room.turn_seq, created_at=room.created_at)
             )
-        )
 
-        for room in self._pending_rooms:
-            self._db._save_room(room)
-        for stroke in self._pending_strokes:
-            self._db._save_stroke(stroke)
-        for member in self._pending_members:
-            self._db._save_member(member)
-        for obj in self._pending_objects:
-            self._db._save_object(obj)
-        for stroke in self._updated_strokes:
-            self._db._strokes[stroke.id] = stroke
-        for turn in self._pending_turns:
-            self._db._save_turn(turn)
-        for log in self._pending_audit_logs:
-            self._db._save_audit_log(log)
-        self._pending_rooms.clear()
-        self._pending_strokes.clear()
-        self._pending_members.clear()
-        self._pending_objects.clear()
-        self._updated_strokes.clear()
-        self._pending_turns.clear()
-        self._pending_audit_logs.clear()
-        return changed
+        async def get_room(self, room_id: UUID) -> Room:
+            room = await self._session.get(RoomORM, room_id)
+            if room is None:
+                raise LookupError("room_not_found")
+            return room.to_domain()
+
+        async def list_room_members(self, room_id: UUID) -> list[RoomMember]:
+            stmt: Select[tuple[RoomMemberORM]] = (
+                select(RoomMemberORM).where(RoomMemberORM.room_id == room_id).order_by(RoomMemberORM.joined_at)
+            )
+            result = await self._session.execute(stmt)
+            return [row[0].to_domain() for row in result.all()]
+
+        async def save_room_member(self, member: RoomMember) -> None:
+            self._session.add(RoomMemberORM.from_domain(member))
+
+        async def get_room_member(self, room_id: UUID, user_id: UUID) -> RoomMember:
+            member = await self._session.get(RoomMemberORM, (room_id, user_id))
+            if member is None:
+                raise LookupError("member_not_found")
+            return member.to_domain()
+
+        async def save_stroke(self, stroke: Stroke) -> None:
+            self._session.add(StrokeORM.from_domain(stroke))
+
+        async def list_strokes(self, room_id: UUID) -> list[Stroke]:
+            stmt: Select[tuple[StrokeORM]] = (
+                select(StrokeORM).where(StrokeORM.room_id == room_id).order_by(StrokeORM.ts)
+            )
+            result = await self._session.execute(stmt)
+            return [row[0].to_domain() for row in result.all()]
+
+        async def get_stroke(self, stroke_id: UUID) -> Stroke:
+            stroke = await self._session.get(StrokeORM, stroke_id)
+            if stroke is None:
+                raise LookupError("stroke_not_found")
+            return stroke.to_domain()
+
+        async def get_strokes(self, room_id: UUID, stroke_ids: Iterable[UUID]) -> list[Stroke]:
+            ids = list(stroke_ids)
+            if not ids:
+                return []
+            stmt: Select[tuple[StrokeORM]] = select(StrokeORM).where(StrokeORM.id.in_(ids))
+            result = await self._session.execute(stmt)
+            strokes = {row[0].id: row[0].to_domain() for row in result.all()}
+            missing = [stroke_id for stroke_id in ids if stroke_id not in strokes]
+            if missing:
+                raise LookupError("stroke_not_found")
+            ordered: list[Stroke] = []
+            for stroke_id in ids:
+                stroke = strokes[stroke_id]
+                if stroke.room_id != room_id:
+                    raise LookupError("stroke_not_found")
+                ordered.append(stroke)
+            return ordered
+
+        async def update_stroke(self, stroke: Stroke, *, object_id: UUID) -> None:
+            await self._session.execute(
+                update(StrokeORM).where(StrokeORM.id == stroke.id).values(object_id=object_id)
+            )
+
+        async def save_object(self, obj: CanvasObject) -> None:
+            self._session.add(ObjectORM.from_domain(obj))
+
+        async def get_object(self, object_id: UUID) -> CanvasObject:
+            obj = await self._session.get(ObjectORM, object_id)
+            if obj is None:
+                raise LookupError("object_not_found")
+            return obj.to_domain()
+
+        async def list_objects(self, room_id: UUID) -> list[CanvasObject]:
+            stmt: Select[tuple[ObjectORM]] = (
+                select(ObjectORM).where(ObjectORM.room_id == room_id).order_by(ObjectORM.created_at)
+            )
+            result = await self._session.execute(stmt)
+            return [row[0].to_domain() for row in result.all()]
+
+        async def save_turn(self, turn: Turn) -> None:
+            self._session.add(TurnORM.from_domain(turn))
+
+        async def update_turn(self, turn: Turn) -> None:
+            await self._session.execute(
+                update(TurnORM)
+                .where(TurnORM.id == turn.id)
+                .values(
+                    status=str(turn.status),
+                    current_actor=str(turn.current_actor),
+                    ai_patch_uri=turn.ai_patch_uri,
+                    safety_status=turn.safety_status,
+                    updated_at=turn.updated_at,
+                )
+            )
+
+        async def get_turn(self, turn_id: UUID) -> Turn:
+            turn = await self._session.get(TurnORM, turn_id)
+            if turn is None:
+                raise LookupError("turn_not_found")
+            return turn.to_domain()
+
+        async def get_turns_for_room(self, room_id: UUID) -> list[Turn]:
+            stmt: Select[tuple[TurnORM]] = (
+                select(TurnORM).where(TurnORM.room_id == room_id).order_by(TurnORM.sequence)
+            )
+            result = await self._session.execute(stmt)
+            return [row[0].to_domain() for row in result.all()]
+
+        async def append_audit_log(self, log: AuditLog) -> None:
+            self._session.add(AuditLogORM.from_domain(log))
+
+        async def list_audit_logs(self, room_id: UUID | None = None) -> list[AuditLog]:
+            stmt: Select[tuple[AuditLogORM]] = select(AuditLogORM)
+            if room_id is not None:
+                stmt = stmt.where(AuditLogORM.room_id == room_id)
+            stmt = stmt.order_by(AuditLogORM.ts)
+            result = await self._session.execute(stmt)
+            return [row[0].to_domain() for row in result.all()]
+
+
+else:  # pragma: no cover - exercised in CI when SQLAlchemy unavailable
+
+    class Database:
+        """In-memory database fallback used when SQLAlchemy is unavailable."""
+
+        def __init__(self, *, database_url: str | None = None, storage_path: str | Path | None = None) -> None:
+            self._rooms: dict[UUID, Room] = {}
+            self._strokes: dict[UUID, Stroke] = {}
+            self._objects: dict[UUID, CanvasObject] = {}
+            self._turns: dict[UUID, Turn] = {}
+            self._audit_logs: dict[UUID, AuditLog] = {}
+            self._members: dict[tuple[UUID, UUID], RoomMember] = {}
+            self._room_member_index: defaultdict[UUID, list[UUID]] = defaultdict(list)
+            self._room_turn_index: defaultdict[UUID, list[UUID]] = defaultdict(list)
+            self._lock = asyncio.Lock()
+            self._storage_path = Path(storage_path).expanduser() if storage_path else None
+            if self._storage_path:
+                self._storage_path.parent.mkdir(parents=True, exist_ok=True)
+                self._load_from_disk()
+
+        async def create_all(self) -> None:  # pragma: no cover - no-op for fallback
+            return None
+
+        async def dispose(self) -> None:  # pragma: no cover - no resources to release
+            return None
+
+        @asynccontextmanager
+        async def transaction(self) -> AsyncIterator["DatabaseSession"]:
+            async with self._lock:
+                session = DatabaseSession(self)
+                yield session
+                if await session.commit():
+                    self._persist()
+
+        # Persistence helpers -------------------------------------------------
+
+        def _persist(self) -> None:
+            if self._storage_path is None:
+                return
+            payload = {
+                "rooms": [self._serialise_room(room) for room in self._rooms.values()],
+                "strokes": [self._serialise_stroke(stroke) for stroke in self._strokes.values()],
+                "objects": [self._serialise_object(obj) for obj in self._objects.values()],
+                "turns": [self._serialise_turn(turn) for turn in self._turns.values()],
+                "audit_logs": [self._serialise_audit(log) for log in self._audit_logs.values()],
+                "members": [self._serialise_member(member) for member in self._members.values()],
+            }
+            tmp_path = self._storage_path.with_suffix(".tmp")
+            with tmp_path.open("w", encoding="utf-8") as fh:
+                json.dump(payload, fh, indent=2)
+            tmp_path.replace(self._storage_path)
+
+        def _load_from_disk(self) -> None:
+            if self._storage_path is None or not self._storage_path.exists():
+                return
+            with self._storage_path.open("r", encoding="utf-8") as fh:
+                data = json.load(fh)
+
+            self._rooms = {UUID(item["id"]): self._deserialise_room(item) for item in data.get("rooms", [])}
+            self._strokes = {
+                UUID(item["id"]): self._deserialise_stroke(item) for item in data.get("strokes", [])
+            }
+            self._objects = {
+                UUID(item["id"]): self._deserialise_object(item) for item in data.get("objects", [])
+            }
+            self._turns = {UUID(item["id"]): self._deserialise_turn(item) for item in data.get("turns", [])}
+            self._audit_logs = {
+                UUID(item["id"]): self._deserialise_audit(item) for item in data.get("audit_logs", [])
+            }
+            self._members = {
+                (UUID(item["room_id"]), UUID(item["user_id"])): self._deserialise_member(item)
+                for item in data.get("members", [])
+            }
+
+            self._room_member_index.clear()
+            for member in self._members.values():
+                self._room_member_index[member.room_id].append(member.user_id)
+
+            self._room_turn_index.clear()
+            for turn in self._turns.values():
+                self._room_turn_index[turn.room_id].append(turn.id)
+
+        @staticmethod
+        def _serialise_room(room: Room) -> dict[str, object]:
+            return {
+                "id": str(room.id),
+                "name": room.name,
+                "turn_seq": room.turn_seq,
+                "created_at": room.created_at.isoformat(),
+            }
+
+        @staticmethod
+        def _deserialise_room(data: dict[str, object]) -> Room:
+            return Room(
+                id=UUID(str(data["id"])),
+                name=str(data["name"]),
+                turn_seq=int(data.get("turn_seq", 0)),
+                created_at=datetime.fromisoformat(str(data["created_at"])),
+            )
+
+        @staticmethod
+        def _serialise_point(point: "Point") -> dict[str, float]:
+            return {"x": point.x, "y": point.y}
+
+        @staticmethod
+        def _deserialise_point(data: dict[str, object]) -> Point:
+            return Point(float(data["x"]), float(data["y"]))
+
+        @classmethod
+        def _serialise_stroke(cls, stroke: Stroke) -> dict[str, object]:
+            return {
+                "id": str(stroke.id),
+                "room_id": str(stroke.room_id),
+                "author_id": str(stroke.author_id),
+                "color": stroke.color,
+                "width": stroke.width,
+                "ts": stroke.ts.isoformat(),
+                "path": [cls._serialise_point(point) for point in stroke.path],
+                "object_id": str(stroke.object_id) if stroke.object_id else None,
+            }
+
+        @classmethod
+        def _deserialise_stroke(cls, data: dict[str, object]) -> Stroke:
+            from ..models import Point
+
+            path = [cls._deserialise_point(point) for point in data.get("path", [])]  # type: ignore[arg-type]
+            object_id = data.get("object_id")
+            return Stroke(
+                id=UUID(str(data["id"])),
+                room_id=UUID(str(data["room_id"])),
+                author_id=UUID(str(data["author_id"])),
+                path=path,
+                color=str(data["color"]),
+                width=float(data["width"]),
+                ts=datetime.fromisoformat(str(data["ts"])),
+                object_id=UUID(object_id) if object_id else None,
+            )
+
+        @staticmethod
+        def _serialise_bbox(bbox: "BBox") -> dict[str, float]:
+            return bbox.to_dict()
+
+        @staticmethod
+        def _deserialise_bbox(data: dict[str, object]) -> "BBox":
+            from ..models import BBox
+
+            return BBox(
+                x=float(data["x"]),
+                y=float(data["y"]),
+                width=float(data["width"]),
+                height=float(data["height"]),
+            )
+
+        @classmethod
+        def _serialise_object(cls, obj: CanvasObject) -> dict[str, object]:
+            return {
+                "id": str(obj.id),
+                "room_id": str(obj.room_id),
+                "owner_id": str(obj.owner_id),
+                "bbox": cls._serialise_bbox(obj.bbox),
+                "anchor_ring": {
+                    "inner": cls._serialise_bbox(obj.anchor_ring.inner),
+                    "outer": cls._serialise_bbox(obj.anchor_ring.outer),
+                },
+                "status": str(obj.status),
+                "label": obj.label,
+                "created_at": obj.created_at.isoformat(),
+            }
+
+        @classmethod
+        def _deserialise_object(cls, data: dict[str, object]) -> CanvasObject:
+            anchor = AnchorRing(
+                inner=cls._deserialise_bbox(data["anchor_ring"]["inner"]),  # type: ignore[index]
+                outer=cls._deserialise_bbox(data["anchor_ring"]["outer"]),  # type: ignore[index]
+            )
+            return CanvasObject(
+                id=UUID(str(data["id"])),
+                room_id=UUID(str(data["room_id"])),
+                owner_id=UUID(str(data["owner_id"])),
+                bbox=cls._deserialise_bbox(data["bbox"]),
+                anchor_ring=anchor,
+                status=ObjectStatus(str(data["status"])),
+                label=data.get("label"),
+                created_at=datetime.fromisoformat(str(data["created_at"])),
+            )
+
+        @staticmethod
+        def _serialise_turn(turn: Turn) -> dict[str, object]:
+            return {
+                "id": str(turn.id),
+                "room_id": str(turn.room_id),
+                "sequence": turn.sequence,
+                "status": str(turn.status),
+                "current_actor": str(turn.current_actor),
+                "source_object_id": str(turn.source_object_id),
+                "ai_patch_uri": turn.ai_patch_uri,
+                "safety_status": turn.safety_status,
+                "created_at": turn.created_at.isoformat(),
+                "updated_at": turn.updated_at.isoformat(),
+            }
+
+        @staticmethod
+        def _deserialise_turn(data: dict[str, object]) -> Turn:
+            return Turn(
+                id=UUID(str(data["id"])),
+                room_id=UUID(str(data["room_id"])),
+                sequence=int(data["sequence"]),
+                status=TurnStatus(str(data["status"])),
+                current_actor=TurnActor(str(data["current_actor"])),
+                source_object_id=UUID(str(data["source_object_id"])),
+                ai_patch_uri=data.get("ai_patch_uri"),
+                safety_status=data.get("safety_status"),
+                created_at=datetime.fromisoformat(str(data["created_at"])),
+                updated_at=datetime.fromisoformat(str(data["updated_at"])),
+            )
+
+        @staticmethod
+        def _serialise_audit(log: AuditLog) -> dict[str, object]:
+            return {
+                "id": str(log.id),
+                "room_id": str(log.room_id),
+                "user_id": str(log.user_id) if log.user_id else None,
+                "turn_id": str(log.turn_id) if log.turn_id else None,
+                "event_type": log.event_type,
+                "payload": log.payload,
+                "ts": log.ts.isoformat(),
+            }
+
+        @staticmethod
+        def _deserialise_audit(data: dict[str, object]) -> AuditLog:
+            user_id = data.get("user_id")
+            turn_id = data.get("turn_id")
+            return AuditLog(
+                id=UUID(str(data["id"])),
+                room_id=UUID(str(data["room_id"])),
+                user_id=UUID(str(user_id)) if user_id else None,
+                turn_id=UUID(str(turn_id)) if turn_id else None,
+                event_type=str(data["event_type"]),
+                payload=data["payload"],  # type: ignore[arg-type]
+                ts=datetime.fromisoformat(str(data["ts"])),
+            )
+
+        @staticmethod
+        def _serialise_member(member: RoomMember) -> dict[str, object]:
+            return {
+                "room_id": str(member.room_id),
+                "user_id": str(member.user_id),
+                "role": str(member.role),
+                "joined_at": member.joined_at.isoformat(),
+            }
+
+        @staticmethod
+        def _deserialise_member(data: dict[str, object]) -> RoomMember:
+            return RoomMember(
+                room_id=UUID(str(data["room_id"])),
+                user_id=UUID(str(data["user_id"])),
+                role=RoomRole(str(data["role"])),
+                joined_at=datetime.fromisoformat(str(data["joined_at"])),
+            )
+
+
+    class DatabaseSession:
+        def __init__(self, db: Database) -> None:
+            self._db = db
+            self._pending_audit_logs: list[AuditLog] = []
+            self._pending_turns: list[Turn] = []
+            self._pending_objects: list[CanvasObject] = []
+            self._pending_rooms: list[Room] = []
+            self._pending_strokes: list[Stroke] = []
+            self._pending_members: list[RoomMember] = []
+            self._updated_strokes: list[Stroke] = []
+
+        async def save_room(self, room: Room) -> None:
+            self._pending_rooms.append(room)
+
+        async def update_room(self, room: Room) -> None:
+            self._pending_rooms.append(room)
+
+        async def get_room(self, room_id: UUID) -> Room:
+            room = self._db._rooms.get(room_id)
+            if room is None:
+                raise LookupError("room_not_found")
+            return room
+
+        async def list_room_members(self, room_id: UUID) -> list[RoomMember]:
+            members = [self._db._members[(room_id, user_id)] for user_id in self._db._room_member_index.get(room_id, [])]
+            for member in self._pending_members:
+                if member.room_id == room_id and member not in members:
+                    members.append(member)
+            return members
+
+        async def save_room_member(self, member: RoomMember) -> None:
+            self._pending_members.append(member)
+
+        async def get_room_member(self, room_id: UUID, user_id: UUID) -> RoomMember:
+            member = self._db._members.get((room_id, user_id))
+            if member is None:
+                raise LookupError("member_not_found")
+            return member
+
+        async def save_stroke(self, stroke: Stroke) -> None:
+            self._pending_strokes.append(stroke)
+
+        async def list_strokes(self, room_id: UUID) -> list[Stroke]:
+            strokes = [stroke for stroke in self._db._strokes.values() if stroke.room_id == room_id]
+            strokes.extend(stroke for stroke in self._pending_strokes if stroke.room_id == room_id)
+            return sorted(strokes, key=lambda stroke: stroke.ts)
+
+        async def get_stroke(self, stroke_id: UUID) -> Stroke:
+            stroke = self._db._strokes.get(stroke_id)
+            if stroke is None:
+                raise LookupError("stroke_not_found")
+            return stroke
+
+        async def get_strokes(self, room_id: UUID, stroke_ids: Iterable[UUID]) -> list[Stroke]:
+            found: list[Stroke] = []
+            for stroke_id in stroke_ids:
+                stroke = self._db._strokes.get(stroke_id)
+                if stroke is None or stroke.room_id != room_id:
+                    raise LookupError("stroke_not_found")
+                found.append(stroke)
+            return found
+
+        async def update_stroke(self, stroke: Stroke, *, object_id: UUID) -> None:
+            updated = replace(stroke, object_id=object_id)
+            self._updated_strokes.append(updated)
+
+        async def save_object(self, obj: CanvasObject) -> None:
+            self._pending_objects.append(obj)
+
+        async def get_object(self, object_id: UUID) -> CanvasObject:
+            obj = self._db._objects.get(object_id)
+            if obj is None:
+                raise LookupError("object_not_found")
+            return obj
+
+        async def list_objects(self, room_id: UUID) -> list[CanvasObject]:
+            return [obj for obj in self._db._objects.values() if obj.room_id == room_id]
+
+        async def save_turn(self, turn: Turn) -> None:
+            self._pending_turns.append(turn)
+
+        async def update_turn(self, turn: Turn) -> None:
+            self._pending_turns.append(turn)
+
+        async def get_turn(self, turn_id: UUID) -> Turn:
+            turn = self._db._turns.get(turn_id)
+            if turn is None:
+                raise LookupError("turn_not_found")
+            return turn
+
+        async def get_turns_for_room(self, room_id: UUID) -> list[Turn]:
+            return [self._db._turns[turn_id] for turn_id in self._db._room_turn_index.get(room_id, [])]
+
+        async def append_audit_log(self, log: AuditLog) -> None:
+            self._pending_audit_logs.append(log)
+
+        async def list_audit_logs(self, room_id: UUID | None = None) -> list[AuditLog]:
+            logs = list(self._db._audit_logs.values())
+            if room_id is not None:
+                logs = [log for log in logs if log.room_id == room_id]
+            return logs
+
+        async def commit(self) -> bool:
+            changed = any(
+                collection
+                for collection in (
+                    self._pending_rooms,
+                    self._pending_strokes,
+                    self._pending_members,
+                    self._pending_objects,
+                    self._updated_strokes,
+                    self._pending_turns,
+                    self._pending_audit_logs,
+                )
+            )
+
+            for room in self._pending_rooms:
+                self._db._rooms[room.id] = room
+            for stroke in self._pending_strokes:
+                self._db._strokes[stroke.id] = stroke
+            for member in self._pending_members:
+                key = (member.room_id, member.user_id)
+                if key not in self._db._members:
+                    self._db._room_member_index[member.room_id].append(member.user_id)
+                self._db._members[key] = member
+            for obj in self._pending_objects:
+                self._db._objects[obj.id] = obj
+            for stroke in self._updated_strokes:
+                self._db._strokes[stroke.id] = stroke
+            for turn in self._pending_turns:
+                self._db._turns[turn.id] = turn
+                if turn.id not in self._db._room_turn_index[turn.room_id]:
+                    self._db._room_turn_index[turn.room_id].append(turn.id)
+            for log in self._pending_audit_logs:
+                self._db._audit_logs[log.id] = log
+
+            self._pending_rooms.clear()
+            self._pending_strokes.clear()
+            self._pending_members.clear()
+            self._pending_objects.clear()
+            self._updated_strokes.clear()
+            self._pending_turns.clear()
+            self._pending_audit_logs.clear()
+            return changed
 
 
 _db_instance: Database | None = None
@@ -457,8 +618,10 @@ def get_database() -> Database:
     global _db_instance  # noqa: PLW0603
     if _db_instance is None:
         settings = get_settings()
-        storage = getattr(settings, "state_file", None) or None
-        _db_instance = Database(storage_path=storage)
+        if SQLALCHEMY_AVAILABLE:
+            _db_instance = Database()
+        else:
+            _db_instance = Database(storage_path=getattr(settings, "state_file", None) or None)
     return _db_instance
 
 

--- a/backend/app/core/db/__init__.py
+++ b/backend/app/core/db/__init__.py
@@ -1,0 +1,4 @@
+"""Database ORM models and helpers."""
+from .models import Base
+
+__all__ = ["Base"]

--- a/backend/app/core/db/models.py
+++ b/backend/app/core/db/models.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+from uuid import UUID, uuid4
+
+from sqlalchemy import JSON, DateTime, Float, ForeignKey, Integer, String
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+from sqlalchemy.types import CHAR, TypeDecorator
+
+from ...models import (
+    AnchorRing,
+    AuditLog,
+    BBox,
+    CanvasObject,
+    ObjectStatus,
+    Point,
+    Room,
+    RoomMember,
+    RoomRole,
+    Stroke,
+    Turn,
+    TurnActor,
+    TurnStatus,
+)
+
+
+class GUID(TypeDecorator):
+    """Platform-independent GUID type."""
+
+    impl = CHAR
+    cache_ok = True
+
+    def load_dialect_impl(self, dialect):  # type: ignore[override]
+        if dialect.name == "postgresql":
+            return dialect.type_descriptor(PG_UUID(as_uuid=True))
+        return dialect.type_descriptor(CHAR(36))
+
+    def process_bind_param(self, value: UUID | None, dialect):  # type: ignore[override]
+        if value is None:
+            return value
+        if dialect.name == "postgresql":
+            return value
+        return str(value)
+
+    def process_result_value(self, value, dialect):  # type: ignore[override]
+        if value is None:
+            return value
+        if isinstance(value, UUID):
+            return value
+        return UUID(str(value))
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class RoomORM(Base):
+    __tablename__ = "rooms"
+
+    id: Mapped[UUID] = mapped_column(GUID(), primary_key=True, default=uuid4)
+    name: Mapped[str] = mapped_column(String(200), nullable=False)
+    turn_seq: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False
+    )
+
+    def to_domain(self) -> Room:
+        return Room(id=self.id, name=self.name, turn_seq=self.turn_seq, created_at=self.created_at)
+
+    @classmethod
+    def from_domain(cls, room: Room) -> "RoomORM":
+        return cls(id=room.id, name=room.name, turn_seq=room.turn_seq, created_at=room.created_at)
+
+
+class RoomMemberORM(Base):
+    __tablename__ = "room_members"
+
+    room_id: Mapped[UUID] = mapped_column(GUID(), ForeignKey("rooms.id", ondelete="CASCADE"), primary_key=True)
+    user_id: Mapped[UUID] = mapped_column(GUID(), primary_key=True)
+    role: Mapped[str] = mapped_column(String(50), nullable=False)
+    joined_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False
+    )
+
+    def to_domain(self) -> RoomMember:
+        return RoomMember(
+            room_id=self.room_id,
+            user_id=self.user_id,
+            role=RoomRole(self.role),
+            joined_at=self.joined_at,
+        )
+
+    @classmethod
+    def from_domain(cls, member: RoomMember) -> "RoomMemberORM":
+        return cls(
+            room_id=member.room_id,
+            user_id=member.user_id,
+            role=str(member.role),
+            joined_at=member.joined_at,
+        )
+
+
+class StrokeORM(Base):
+    __tablename__ = "strokes"
+
+    id: Mapped[UUID] = mapped_column(GUID(), primary_key=True, default=uuid4)
+    room_id: Mapped[UUID] = mapped_column(GUID(), ForeignKey("rooms.id", ondelete="CASCADE"), nullable=False)
+    author_id: Mapped[UUID] = mapped_column(GUID(), nullable=False)
+    color: Mapped[str] = mapped_column(String(50), nullable=False)
+    width: Mapped[float] = mapped_column(Float, nullable=False)
+    ts: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False
+    )
+    path: Mapped[list[dict[str, float]]] = mapped_column(JSON, nullable=False)
+    object_id: Mapped[UUID | None] = mapped_column(GUID(), ForeignKey("objects.id", ondelete="SET NULL"))
+
+    def to_domain(self) -> Stroke:
+        points = [Point(float(item["x"]), float(item["y"])) for item in self.path]
+        return Stroke(
+            id=self.id,
+            room_id=self.room_id,
+            author_id=self.author_id,
+            path=points,
+            color=self.color,
+            width=self.width,
+            ts=self.ts,
+            object_id=self.object_id,
+        )
+
+    @classmethod
+    def from_domain(cls, stroke: Stroke) -> "StrokeORM":
+        return cls(
+            id=stroke.id,
+            room_id=stroke.room_id,
+            author_id=stroke.author_id,
+            color=stroke.color,
+            width=stroke.width,
+            ts=stroke.ts,
+            path=[{"x": point.x, "y": point.y} for point in stroke.path],
+            object_id=stroke.object_id,
+        )
+
+
+class ObjectORM(Base):
+    __tablename__ = "objects"
+
+    id: Mapped[UUID] = mapped_column(GUID(), primary_key=True, default=uuid4)
+    room_id: Mapped[UUID] = mapped_column(GUID(), ForeignKey("rooms.id", ondelete="CASCADE"), nullable=False)
+    owner_id: Mapped[UUID] = mapped_column(GUID(), nullable=False)
+    bbox: Mapped[dict[str, float]] = mapped_column(JSON, nullable=False)
+    anchor_ring: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)
+    status: Mapped[str] = mapped_column(String(20), nullable=False)
+    label: Mapped[str | None] = mapped_column(String(120))
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False
+    )
+
+    def to_domain(self) -> CanvasObject:
+        return CanvasObject(
+            id=self.id,
+            room_id=self.room_id,
+            owner_id=self.owner_id,
+            bbox=_bbox_from_json(self.bbox),
+            anchor_ring=_anchor_from_json(self.anchor_ring),
+            status=ObjectStatus(self.status),
+            label=self.label,
+            created_at=self.created_at,
+        )
+
+    @classmethod
+    def from_domain(cls, obj: CanvasObject) -> "ObjectORM":
+        return cls(
+            id=obj.id,
+            room_id=obj.room_id,
+            owner_id=obj.owner_id,
+            bbox=obj.bbox.to_dict(),
+            anchor_ring=obj.anchor_ring.to_dict(),
+            status=str(obj.status),
+            label=obj.label,
+            created_at=obj.created_at,
+        )
+
+
+class TurnORM(Base):
+    __tablename__ = "turns"
+
+    id: Mapped[UUID] = mapped_column(GUID(), primary_key=True, default=uuid4)
+    room_id: Mapped[UUID] = mapped_column(GUID(), ForeignKey("rooms.id", ondelete="CASCADE"), nullable=False)
+    sequence: Mapped[int] = mapped_column(Integer, nullable=False)
+    status: Mapped[str] = mapped_column(String(30), nullable=False)
+    current_actor: Mapped[str] = mapped_column(String(30), nullable=False)
+    source_object_id: Mapped[UUID] = mapped_column(GUID(), ForeignKey("objects.id", ondelete="CASCADE"), nullable=False)
+    ai_patch_uri: Mapped[str | None] = mapped_column(String(500))
+    safety_status: Mapped[str | None] = mapped_column(String(50))
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False
+    )
+
+    def to_domain(self) -> Turn:
+        return Turn(
+            id=self.id,
+            room_id=self.room_id,
+            sequence=self.sequence,
+            status=TurnStatus(self.status),
+            current_actor=TurnActor(self.current_actor),
+            source_object_id=self.source_object_id,
+            ai_patch_uri=self.ai_patch_uri,
+            safety_status=self.safety_status,
+            created_at=self.created_at,
+            updated_at=self.updated_at,
+        )
+
+    @classmethod
+    def from_domain(cls, turn: Turn) -> "TurnORM":
+        return cls(
+            id=turn.id,
+            room_id=turn.room_id,
+            sequence=turn.sequence,
+            status=str(turn.status),
+            current_actor=str(turn.current_actor),
+            source_object_id=turn.source_object_id,
+            ai_patch_uri=turn.ai_patch_uri,
+            safety_status=turn.safety_status,
+            created_at=turn.created_at,
+            updated_at=turn.updated_at,
+        )
+
+
+class AuditLogORM(Base):
+    __tablename__ = "audit_logs"
+
+    id: Mapped[UUID] = mapped_column(GUID(), primary_key=True, default=uuid4)
+    room_id: Mapped[UUID] = mapped_column(GUID(), ForeignKey("rooms.id", ondelete="CASCADE"), nullable=False)
+    user_id: Mapped[UUID | None] = mapped_column(GUID())
+    turn_id: Mapped[UUID | None] = mapped_column(GUID(), ForeignKey("turns.id", ondelete="SET NULL"))
+    event_type: Mapped[str] = mapped_column(String(120), nullable=False)
+    payload: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)
+    ts: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False
+    )
+
+    def to_domain(self) -> AuditLog:
+        return AuditLog(
+            id=self.id,
+            room_id=self.room_id,
+            user_id=self.user_id,
+            turn_id=self.turn_id,
+            event_type=self.event_type,
+            payload=self.payload,
+            ts=self.ts,
+        )
+
+    @classmethod
+    def from_domain(cls, log: AuditLog) -> "AuditLogORM":
+        return cls(
+            id=log.id,
+            room_id=log.room_id,
+            user_id=log.user_id,
+            turn_id=log.turn_id,
+            event_type=log.event_type,
+            payload=log.payload,
+            ts=log.ts,
+        )
+
+
+def _bbox_from_json(data: dict[str, Any]) -> BBox:
+    return BBox(
+        x=float(data["x"]),
+        y=float(data["y"]),
+        width=float(data["width"]),
+        height=float(data["height"]),
+    )
+
+
+def _anchor_from_json(data: dict[str, Any]) -> AnchorRing:
+    inner = _bbox_from_json(data["inner"])
+    outer = _bbox_from_json(data["outer"])
+    return AnchorRing(inner=inner, outer=outer)

--- a/backend/app/core/redis.py
+++ b/backend/app/core/redis.py
@@ -1,4 +1,3 @@
-"""Redis helper with an in-memory fallback for offline testing."""
 from __future__ import annotations
 
 import json
@@ -11,64 +10,175 @@ try:  # pragma: no cover - optional dependency
 except ImportError:  # pragma: no cover - fallback path
     _RedisClient = None  # type: ignore
 
+TIMELINE_STREAM = "ws:timeline"
 
-class InMemoryRedis:
-    """Minimal Redis clone supporting the operations we require."""
+from .config import get_settings
+
+
+class InMemoryEventStore:
+    """Event store that mimics the Redis interface for tests."""
 
     def __init__(self) -> None:
-        self._lists: defaultdict[str, list[str]] = defaultdict(list)
+        self._queues: defaultdict[str, list[str]] = defaultdict(list)
+        self._streams: defaultdict[str, list[dict[str, Any]]] = defaultdict(list)
+        self._sequences: defaultdict[str, int] = defaultdict(int)
+        self._timeline: list[dict[str, Any]] = []
+        self._timeline_seq = 0
 
-    async def rpush(self, key: str, value: str) -> None:
-        self._lists[key].append(value)
+    async def enqueue_stream(self, stream: str, payload: dict[str, Any]) -> dict[str, Any]:
+        self._sequences[stream] += 1
+        sequence = self._sequences[stream]
+        event = {**payload, "sequence": sequence, "stream": stream}
+        self._streams[stream].append(event)
+        self._timeline_seq += 1
+        timeline_cursor = str(self._timeline_seq)
+        timeline_event = {**event, "cursor": timeline_cursor}
+        self._timeline.append(timeline_event)
+        return timeline_event
 
-    async def lrange(self, key: str, start: int, end: int) -> list[str]:
-        items = self._lists.get(key, [])
-        if end == -1:
-            return items[start:]
-        return items[start : end + 1]
+    async def list_stream(self, stream: str) -> list[dict[str, Any]]:
+        return [dict(item) for item in self._streams.get(stream, [])]
 
-    async def lpop(self, key: str) -> str | None:
-        items = self._lists.get(key)
+    async def enqueue_queue(self, key: str, payload: dict[str, Any]) -> None:
+        self._queues[key].append(json.dumps(payload))
+
+    async def list_queue(self, key: str) -> list[dict[str, Any]]:
+        return [json.loads(item) for item in self._queues.get(key, [])]
+
+    async def pop_queue(self, key: str) -> dict[str, Any] | None:
+        items = self._queues.get(key)
         if not items:
             return None
-        return items.pop(0)
+        raw = items.pop(0)
+        return json.loads(raw)
 
-    async def publish(self, channel: str, message: str) -> None:  # pragma: no cover - not used yet
-        self._lists[channel].append(message)
+    async def next_timeline_event(self, cursor: str | None = None) -> dict[str, Any] | None:
+        if cursor is None:
+            return self._timeline[0] if self._timeline else None
+        for event in self._timeline:
+            if event["cursor"] > cursor:
+                return event
+        return None
 
-    async def close(self) -> None:
-        self._lists.clear()
+    async def list_timeline(self, cursor: str | None = None, limit: int | None = None) -> list[dict[str, Any]]:
+        events = self._timeline
+        if cursor is not None:
+            events = [event for event in events if event["cursor"] > cursor]
+        if limit is not None:
+            events = events[:limit]
+        return [dict(event) for event in events]
+
+
+class RedisEventStore:
+    """Wrapper around a real Redis connection."""
+
+    def __init__(self, client: Any) -> None:
+        self._client = client
+
+    async def enqueue_stream(self, stream: str, payload: dict[str, Any]) -> dict[str, Any]:
+        sequence = await self._client.incr(f"seq:{stream}")
+        event = {**payload, "sequence": sequence, "stream": stream}
+        await self._client.xadd(stream, {"data": json.dumps(event)}, maxlen=5000)
+        timeline_event = dict(event)
+        entry_id = await self._client.xadd(TIMELINE_STREAM, {"data": json.dumps(timeline_event)}, maxlen=10000)
+        timeline_event["cursor"] = entry_id
+        return timeline_event
+
+    async def list_stream(self, stream: str) -> list[dict[str, Any]]:
+        entries = await self._client.xrange(stream, "-", "+")
+        events: list[dict[str, Any]] = []
+        for entry_id, fields in entries:
+            data = json.loads(fields.get("data", "{}"))
+            data["cursor"] = entry_id
+            events.append(data)
+        return events
+
+    async def enqueue_queue(self, key: str, payload: dict[str, Any]) -> None:
+        await self._client.rpush(key, json.dumps(payload))
+
+    async def list_queue(self, key: str) -> list[dict[str, Any]]:
+        raw = await self._client.lrange(key, 0, -1)
+        events: list[dict[str, Any]] = []
+        for item in raw:
+            if isinstance(item, bytes):
+                item = item.decode()
+            events.append(json.loads(item))
+        return events
+
+    async def pop_queue(self, key: str) -> dict[str, Any] | None:
+        raw = await self._client.lpop(key)
+        if raw is None:
+            return None
+        if isinstance(raw, bytes):
+            raw = raw.decode()
+        return json.loads(raw)
+
+    async def next_timeline_event(self, cursor: str | None = None) -> dict[str, Any] | None:
+        start = "-" if cursor is None else f"({cursor})"
+        entries = await self._client.xrange(TIMELINE_STREAM, min=start, max="+", count=1)
+        if not entries:
+            return None
+        entry_id, fields = entries[0]
+        data = json.loads(fields.get("data", "{}"))
+        data["cursor"] = entry_id
+        return data
+
+    async def list_timeline(self, cursor: str | None = None, limit: int | None = None) -> list[dict[str, Any]]:
+        start = "-" if cursor is None else f"({cursor})"
+        entries = await self._client.xrange(TIMELINE_STREAM, min=start, max="+", count=limit)
+        events: list[dict[str, Any]] = []
+        for entry_id, fields in entries:
+            data = json.loads(fields.get("data", "{}"))
+            data["cursor"] = entry_id
+            events.append(data)
+        return events
 
 
 class RedisWrapper:
     """Abstraction around redis client to simplify testing."""
 
-    def __init__(self) -> None:
+    def __init__(self, redis_url: str | None = None) -> None:
         if _RedisClient is not None:
-            self._client = _RedisClient.from_url("redis://localhost:6379/0", decode_responses=True)
+            self._client = _RedisClient.from_url(redis_url or "redis://localhost:6379/0", decode_responses=True)
+            self._store: InMemoryEventStore | RedisEventStore = RedisEventStore(self._client)
         else:
-            self._client = InMemoryRedis()
+            self._client = None
+            self._store = InMemoryEventStore()
 
     async def enqueue_json(self, key: str, payload: dict[str, Any]) -> None:
-        await self._client.rpush(key, json.dumps(payload))
+        if key.startswith("turn:"):
+            await self._store.enqueue_queue(key, payload)
+        else:
+            await self._store.enqueue_stream(key, payload)
 
     async def list_events(self, key: str) -> list[dict[str, Any]]:
-        raw = await self._client.lrange(key, 0, -1)
-        return [json.loads(item) for item in raw]
+        if key.startswith("turn:"):
+            return await self._store.list_queue(key)
+        return await self._store.list_stream(key)
 
     async def pop_event(self, key: str) -> dict[str, Any] | None:
-        if hasattr(self._client, "lpop"):
-            raw = await self._client.lpop(key)
-        else:  # pragma: no cover - redis client fallback
-            raw = None
-        if raw is None:
+        if key.startswith("turn:"):
+            return await self._store.pop_queue(key)
+        # For streams we pop via timeline replay; default to None.
+        events = await self._store.list_stream(key)
+        if not events:
             return None
-        if isinstance(raw, bytes):  # pragma: no cover - redis client
-            raw = raw.decode()
-        return json.loads(raw)
+        first = events[0]
+        # Remove the event from stream representation for in-memory store
+        if isinstance(self._store, InMemoryEventStore):
+            stream_events = self._store._streams.get(key, [])  # type: ignore[attr-defined]
+            if stream_events:
+                stream_events.pop(0)
+        return first
 
     async def enqueue_turn_event(self, key: str, payload: dict[str, Any]) -> None:
         await self.enqueue_json(key, payload)
+
+    async def next_timeline_event(self, cursor: str | None = None) -> dict[str, Any] | None:
+        return await self._store.next_timeline_event(cursor)
+
+    async def list_timeline_events(self, cursor: str | None = None, limit: int | None = None) -> list[dict[str, Any]]:
+        return await self._store.list_timeline(cursor, limit)
 
     async def raw_client(self) -> Any:  # pragma: no cover - used for dependency overrides
         return self._client
@@ -80,7 +190,8 @@ _redis_instance: RedisWrapper | None = None
 def get_redis_wrapper() -> RedisWrapper:
     global _redis_instance  # noqa: PLW0603
     if _redis_instance is None:
-        _redis_instance = RedisWrapper()
+        settings = get_settings()
+        _redis_instance = RedisWrapper(redis_url=settings.redis_url)
     return _redis_instance
 
 

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -1,0 +1,99 @@
+"""Security helpers for REST and WebSocket authentication."""
+from __future__ import annotations
+
+import base64
+import hmac
+import json
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from enum import StrEnum
+from hashlib import sha256
+from typing import Callable
+from uuid import UUID
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+from .config import get_settings
+
+
+class UserRole(StrEnum):
+    PLAYER = "player"
+    MODERATOR = "moderator"
+    PARENT = "parent"
+
+
+@dataclass
+class AuthenticatedSubject:
+    user_id: UUID
+    role: UserRole
+
+
+bearer_scheme = HTTPBearer(auto_error=False)
+
+
+def _sign(message: str, secret: str) -> str:
+    return hmac.new(secret.encode(), message.encode(), sha256).hexdigest()
+
+
+def create_access_token(
+    *,
+    user_id: UUID,
+    role: UserRole,
+    expires_delta: timedelta | None = None,
+) -> str:
+    settings = get_settings()
+    expire = datetime.now(timezone.utc) + (
+        expires_delta or timedelta(minutes=settings.access_token_expire_minutes)
+    )
+    payload = {"sub": str(user_id), "role": str(role), "exp": int(expire.timestamp())}
+    encoded = base64.urlsafe_b64encode(json.dumps(payload, separators=(",", ":")).encode()).decode()
+    signature = _sign(encoded, settings.auth_secret_key)
+    return f"{encoded}.{signature}"
+
+
+def decode_token(token: str) -> AuthenticatedSubject:
+    settings = get_settings()
+    try:
+        encoded, signature = token.split(".", 1)
+    except ValueError as exc:  # pragma: no cover - invalid format
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="invalid_token") from exc
+
+    expected = _sign(encoded, settings.auth_secret_key)
+    if not hmac.compare_digest(signature, expected):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="invalid_signature")
+
+    try:
+        payload = json.loads(base64.urlsafe_b64decode(encoded + "==").decode())
+    except Exception as exc:  # pragma: no cover - malformed payload
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="invalid_token") from exc
+
+    try:
+        exp_ts = int(payload.get("exp", 0))
+        if datetime.now(timezone.utc).timestamp() > exp_ts:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="token_expired")
+        role = UserRole(payload["role"])
+        user_id = UUID(str(payload["sub"]))
+    except (ValueError, KeyError) as exc:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="invalid_subject") from exc
+
+    return AuthenticatedSubject(user_id=user_id, role=role)
+
+
+async def get_current_subject(
+    credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme),
+) -> AuthenticatedSubject:
+    if credentials is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="missing_token")
+    return decode_token(credentials.credentials)
+
+
+def require_roles(*roles: UserRole) -> Callable[[AuthenticatedSubject], AuthenticatedSubject]:
+    allowed: set[UserRole] = set(roles)
+
+    async def dependency(subject: AuthenticatedSubject = Depends(get_current_subject)) -> AuthenticatedSubject:
+        if subject.role not in allowed:
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="insufficient_role")
+        return subject
+
+    return dependency

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,6 +12,7 @@ from .api.routes.strokes import router as strokes_router
 from .core.config import get_settings
 from .core.redis import get_redis_wrapper
 from .services.turn_processor import TurnProcessor
+from .ws.rooms import router as rooms_ws_router
 
 
 def create_app() -> FastAPI:
@@ -41,6 +42,7 @@ def create_app() -> FastAPI:
     app.include_router(rooms_router, prefix=settings.api_prefix)
     app.include_router(strokes_router, prefix=settings.api_prefix)
     app.include_router(events_router, prefix=settings.api_prefix)
+    app.include_router(rooms_ws_router)
 
     return app
 

--- a/backend/app/services/audit.py
+++ b/backend/app/services/audit.py
@@ -24,5 +24,5 @@ async def record_audit_event(
         event_type=event_type,
         payload=payload,
     )
-    session.append_audit_log(log)
+    await session.append_audit_log(log)
     return log

--- a/backend/app/services/objects.py
+++ b/backend/app/services/objects.py
@@ -73,12 +73,12 @@ async def create_object(
         )
 
     try:
-        room = session.get_room(room_id)
+        room = await session.get_room(room_id)
     except LookupError:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Room not found") from None
 
     try:
-        strokes = session.get_strokes(room_id, stroke_ids)
+        strokes = await session.get_strokes(room_id, stroke_ids)
     except LookupError:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -103,10 +103,10 @@ async def create_object(
         bbox=bbox.to_bbox(),
         anchor_ring=anchor_ring,
     )
-    session.save_object(canvas_object)
+    await session.save_object(canvas_object)
 
     for stroke in strokes:
-        session.update_stroke(stroke, object_id=canvas_object.id)
+        await session.update_stroke(stroke, object_id=canvas_object.id)
 
     await record_audit_event(
         session,

--- a/backend/app/services/rooms.py
+++ b/backend/app/services/rooms.py
@@ -31,8 +31,8 @@ async def create_room(
     room = Room(name=name)
     member = RoomMember(room_id=room.id, user_id=host_id, role=RoomRole.HOST)
 
-    session.save_room(room)
-    session.save_room_member(member)
+    await session.save_room(room)
+    await session.save_room_member(member)
 
     await record_audit_event(
         session,
@@ -64,22 +64,22 @@ async def join_room(
     user_id: UUID,
 ) -> RoomSnapshot:
     try:
-        room = session.get_room(room_id)
+        room = await session.get_room(room_id)
     except LookupError:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Room not found") from None
 
     try:
-        member = session.get_room_member(room_id, user_id)
+        member = await session.get_room_member(room_id, user_id)
         is_new_member = False
     except LookupError:
         member = RoomMember(room_id=room.id, user_id=user_id, role=RoomRole.PARTICIPANT)
-        session.save_room_member(member)
+        await session.save_room_member(member)
         is_new_member = True
 
-    members = session.list_room_members(room.id)
-    strokes = session.list_strokes(room.id)
-    objects = session.list_objects(room.id)
-    turns = session.get_turns_for_room(room.id)
+    members = await session.list_room_members(room.id)
+    strokes = await session.list_strokes(room.id)
+    objects = await session.list_objects(room.id)
+    turns = await session.get_turns_for_room(room.id)
 
     if is_new_member:
         await record_audit_event(

--- a/backend/app/services/strokes.py
+++ b/backend/app/services/strokes.py
@@ -16,9 +16,9 @@ WS_EVENT_STREAM = "ws:events"
 OBJECT_EVENT_STREAM = "ws:object-events"
 
 
-def _ensure_room(session: DatabaseSession, room_id: UUID) -> Room:
+async def _ensure_room(session: DatabaseSession, room_id: UUID) -> Room:
     try:
-        return session.get_room(room_id)
+        return await session.get_room(room_id)
     except LookupError:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Room not found") from None
 
@@ -49,7 +49,7 @@ async def create_stroke(
     if not path:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Path must contain at least one point")
 
-    room = _ensure_room(session, room_id)
+    room = await _ensure_room(session, room_id)
 
     points = [Point(float(point["x"]), float(point["y"])) for point in path]
 
@@ -60,7 +60,7 @@ async def create_stroke(
         color=color,
         width=width,
     )
-    session.save_stroke(stroke)
+    await session.save_stroke(stroke)
 
     await record_audit_event(
         session,
@@ -88,9 +88,9 @@ async def create_stroke(
     return stroke
 
 
-def list_strokes(session: DatabaseSession, *, room_id: UUID) -> Iterable[Stroke]:
-    _ensure_room(session, room_id)
-    return session.list_strokes(room_id)
+async def list_strokes(session: DatabaseSession, *, room_id: UUID) -> Iterable[Stroke]:
+    await _ensure_room(session, room_id)
+    return await session.list_strokes(room_id)
 
 
 async def broadcast_object_event(

--- a/backend/app/services/turns.py
+++ b/backend/app/services/turns.py
@@ -20,6 +20,7 @@ async def create_turn_for_object(
     user_id: UUID,
 ) -> Turn:
     room.turn_seq += 1
+    await session.update_room(room)
     turn = Turn(
         room_id=room.id,
         sequence=room.turn_seq,
@@ -27,7 +28,7 @@ async def create_turn_for_object(
         current_actor=TurnActor.AI,
         source_object_id=object_id,
     )
-    session.save_turn(turn)
+    await session.save_turn(turn)
 
     await record_audit_event(
         session,

--- a/backend/app/tests/test_strokes.py
+++ b/backend/app/tests/test_strokes.py
@@ -1,10 +1,12 @@
 import asyncio
+import asyncio
 from uuid import uuid4
 
 from ..api.routes.rooms import create_room_endpoint
 from ..api.routes.strokes import create_stroke_endpoint, list_strokes
 from ..core.database import Database
 from ..core.redis import RedisWrapper
+from ..core.security import AuthenticatedSubject, UserRole
 from ..schemas.rooms import RoomCreatePayload
 from ..schemas.strokes import PointSchema, StrokeCreatePayload
 
@@ -14,13 +16,18 @@ def test_create_and_list_strokes() -> None:
 
 
 async def _run_stroke_flow() -> None:
-    db = Database()
+    db = Database(database_url="sqlite+aiosqlite:///:memory:")
+    await db.create_all()
     redis = RedisWrapper()
 
     host_id = uuid4()
     create_payload = RoomCreatePayload(name="Sketch Room", host_id=host_id)
     async with db.transaction() as session:
-        room_response = await create_room_endpoint(payload=create_payload, session=session)
+        room_response = await create_room_endpoint(
+            payload=create_payload,
+            session=session,
+            subject=AuthenticatedSubject(user_id=host_id, role=UserRole.PLAYER),
+        )
 
     room_id = room_response.room.id
     author_id = uuid4()
@@ -38,6 +45,7 @@ async def _run_stroke_flow() -> None:
             payload=stroke_payload,
             session=session,
             redis=redis,
+            subject=AuthenticatedSubject(user_id=author_id, role=UserRole.PLAYER),
         )
 
     assert stroke_response.stroke.room_id == room_id
@@ -50,7 +58,11 @@ async def _run_stroke_flow() -> None:
     assert events[0]["payload"]["roomId"] == str(room_id)
 
     async with db.transaction() as session:
-        list_response = await list_strokes(room_id=room_id, session=session)
+        list_response = await list_strokes(
+            room_id=room_id,
+            session=session,
+            subject=AuthenticatedSubject(user_id=author_id, role=UserRole.PLAYER),
+        )
 
     assert len(list_response.strokes) == 1
     assert list_response.strokes[0].color == "#ff00ff"

--- a/backend/app/ws/rooms.py
+++ b/backend/app/ws/rooms.py
@@ -1,0 +1,68 @@
+"""WebSocket endpoints for room streaming with authentication."""
+from __future__ import annotations
+
+import asyncio
+from uuid import UUID
+
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect, status
+
+from ..core.database import get_database
+from ..core.redis import get_redis_wrapper
+from ..core.security import AuthenticatedSubject, UserRole, decode_token
+
+router = APIRouter()
+
+
+async def _authenticate(websocket: WebSocket) -> AuthenticatedSubject:
+    token = websocket.query_params.get("token")
+    if not token:
+        await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
+        raise WebSocketDisconnect()
+    try:
+        return decode_token(token)
+    except Exception:  # pragma: no cover - validation already covered in security tests
+        await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
+        raise WebSocketDisconnect() from None
+
+
+@router.websocket("/ws/rooms/{room_id}")
+async def room_events(websocket: WebSocket, room_id: UUID) -> None:
+    subject = await _authenticate(websocket)
+    await websocket.accept()
+
+    database = get_database()
+    async with database.transaction() as session:
+        try:
+            await session.get_room(room_id)
+        except LookupError:
+            await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
+            return
+        try:
+            await session.get_room_member(room_id, subject.user_id)
+        except LookupError:
+            if subject.role == UserRole.PLAYER:
+                await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
+                return
+
+    redis = get_redis_wrapper()
+    cursor = websocket.query_params.get("cursor")
+
+    try:
+        backlog = await redis.list_timeline_events(cursor=cursor, limit=50)
+        for event in backlog:
+            if event.get("roomId") != str(room_id):
+                continue
+            cursor = event["cursor"]
+            await websocket.send_json(event)
+
+        while True:
+            event = await redis.next_timeline_event(cursor)
+            if event is None:
+                await asyncio.sleep(0.5)
+                continue
+            cursor = event["cursor"]
+            if event.get("roomId") != str(room_id):
+                continue
+            await websocket.send_json(event)
+    except WebSocketDisconnect:
+        return

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -14,6 +14,11 @@ dependencies = [
     "uvicorn[standard]>=0.27.0",
     "pydantic-settings>=2.2.1",
     "httpx>=0.27.0",
+    "sqlalchemy>=2.0.28",
+    "asyncpg>=0.29.0",
+    "alembic>=1.13.1",
+    "redis>=5.0.1",
+    "python-jose[cryptography]>=3.3.0",
 ]
 
 [project.optional-dependencies]
@@ -23,6 +28,7 @@ dev = [
     "pytest>=8.1.0",
     "pytest-asyncio>=0.23.0",
     "httpx>=0.27.0",
+    "alembic>=1.13.1",
 ]
 
 [tool.black]


### PR DESCRIPTION
## Summary
- add a SQLAlchemy ORM layer with Alembic migrations plus an async in-memory fallback for persistence and testing
- enhance realtime event delivery with Redis-backed timeline replay support exposed via REST and WebSocket APIs
- enforce token-based authentication and role checks across REST endpoints and the new room WebSocket gateway

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68f499335c4083289306345193245218